### PR TITLE
[Issue 133] GZIP File Archive Java Delegate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,12 @@
     </dependency>
 
     <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-compress</artifactId>
+       <version>1.20</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
       <version>2.0b6</version>

--- a/ramls/compressfiletask.json
+++ b/ramls/compressfiletask.json
@@ -43,7 +43,12 @@
       "type" : "string"
     },
     "format" : {
-      "type" : "string"
+      "type" : "string",
+      "enum" : [ "BZIP2", "GZIP" ]
+    },
+    "container" : {
+      "type" : "string",
+      "enum" : [ "NONE", "TAR" ]
     },
     "identifier" : {
       "type" : "string"

--- a/ramls/compressfiletask.json
+++ b/ramls/compressfiletask.json
@@ -1,0 +1,77 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "CompressFileTask",
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "deserializeAs" : {
+      "type" : "string",
+      "enum" : [ "CompressFileTask" ],
+      "default" : "CompressFileTask"
+    },
+    "id" : {
+      "type" : "string"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 3,
+      "maxLength" : 64
+    },
+    "description" : {
+      "type" : "string",
+      "maxLength" : 512
+    },
+    "inputVariables" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/EmbeddedVariable"
+      }
+    },
+    "outputVariable" : {
+      "$ref" : "#/definitions/EmbeddedVariable"
+    },
+    "asyncBefore" : {
+      "type" : "boolean"
+    },
+    "asyncAfter" : {
+      "type" : "boolean"
+    },
+    "source" : {
+      "type" : "string"
+    },
+    "destination" : {
+      "type" : "string"
+    },
+    "format" : {
+      "type" : "string"
+    },
+    "identifier" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ],
+  "definitions" : {
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
+    }
+  }
+}

--- a/ramls/compresstask.json
+++ b/ramls/compresstask.json
@@ -1,0 +1,78 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema#",
+  "title" : "CompressTask",
+  "type" : "object",
+  "additionalProperties" : false,
+  "properties" : {
+    "deserializeAs" : {
+      "type" : "string",
+      "enum" : [ "CompressTask" ],
+      "default" : "CompressTask"
+    },
+    "id" : {
+      "type" : "string"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 3,
+      "maxLength" : 64
+    },
+    "description" : {
+      "type" : "string",
+      "maxLength" : 512
+    },
+    "inputVariables" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/EmbeddedVariable"
+      }
+    },
+    "outputVariable" : {
+      "$ref" : "#/definitions/EmbeddedVariable"
+    },
+    "asyncBefore" : {
+      "type" : "boolean"
+    },
+    "asyncAfter" : {
+      "type" : "boolean"
+    },
+    "source" : {
+      "type" : "string"
+    },
+    "destination" : {
+      "type" : "string"
+    },
+    "format" : {
+      "type" : "string",
+      "enum" : [ "BZIP2", "GZIP" ]
+    },
+    "identifier" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ],
+  "definitions" : {
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
+    }
+  }
+}

--- a/ramls/conditionalgateway.json
+++ b/ramls/conditionalgateway.json
@@ -51,6 +51,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -205,6 +207,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -274,6 +278,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -379,6 +385,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -411,6 +419,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -466,28 +548,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1043,6 +1103,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1124,6 +1186,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/conditionalgateway.json
+++ b/ramls/conditionalgateway.json
@@ -463,7 +463,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/ramls/eventsubprocess.json
+++ b/ramls/eventsubprocess.json
@@ -449,7 +449,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/ramls/eventsubprocess.json
+++ b/ramls/eventsubprocess.json
@@ -37,6 +37,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -191,6 +193,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -260,6 +264,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -365,6 +371,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -397,6 +405,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -452,28 +534,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1029,6 +1089,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1110,6 +1172,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/movetonode.json
+++ b/ramls/movetonode.json
@@ -452,7 +452,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/ramls/movetonode.json
+++ b/ramls/movetonode.json
@@ -40,6 +40,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -194,6 +196,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -263,6 +267,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -368,6 +374,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -400,6 +408,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -455,28 +537,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1032,6 +1092,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1113,6 +1175,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/parallelgateway.json
+++ b/ramls/parallelgateway.json
@@ -449,7 +449,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/ramls/parallelgateway.json
+++ b/ramls/parallelgateway.json
@@ -37,6 +37,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -191,6 +193,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -260,6 +264,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -365,6 +371,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -397,6 +405,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -452,28 +534,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1029,6 +1089,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1110,6 +1172,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/subprocess.json
+++ b/ramls/subprocess.json
@@ -41,6 +41,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -207,6 +209,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -276,6 +280,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -381,6 +387,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -413,6 +421,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -468,28 +550,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1045,6 +1105,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1126,6 +1188,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/subprocess.json
+++ b/ramls/subprocess.json
@@ -465,7 +465,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/ramls/workflow.json
+++ b/ramls/workflow.json
@@ -50,6 +50,8 @@
         }, {
           "$ref" : "#/definitions/MoveToNode"
         }, {
+          "$ref" : "#/definitions/CompressFileTask"
+        }, {
           "$ref" : "#/definitions/DatabaseConnectionTask"
         }, {
           "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -218,6 +220,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -287,6 +291,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
@@ -392,6 +398,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -424,6 +432,80 @@
       },
       "title" : "MoveToNode",
       "required" : [ "deserializeAs", "name", "gatewayId" ]
+    },
+    "CompressFileTask" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "deserializeAs" : {
+          "type" : "string",
+          "enum" : [ "CompressFileTask" ],
+          "default" : "CompressFileTask"
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string",
+          "minLength" : 3,
+          "maxLength" : 64
+        },
+        "description" : {
+          "type" : "string",
+          "maxLength" : 512
+        },
+        "inputVariables" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/EmbeddedVariable"
+          }
+        },
+        "outputVariable" : {
+          "$ref" : "#/definitions/EmbeddedVariable"
+        },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
+        "source" : {
+          "type" : "string"
+        },
+        "destination" : {
+          "type" : "string"
+        },
+        "format" : {
+          "type" : "string"
+        },
+        "identifier" : {
+          "type" : "string"
+        }
+      },
+      "title" : "CompressFileTask",
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
+    },
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
     },
     "DatabaseConnectionTask" : {
       "type" : "object",
@@ -479,28 +561,6 @@
       },
       "title" : "DatabaseConnectionTask",
       "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     },
     "DatabaseDisconnectTask" : {
       "type" : "object",
@@ -1056,6 +1116,8 @@
             }, {
               "$ref" : "#/definitions/MoveToNode"
             }, {
+              "$ref" : "#/definitions/CompressFileTask"
+            }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {
               "$ref" : "#/definitions/DatabaseDisconnectTask"
@@ -1137,6 +1199,8 @@
               "$ref" : "#/definitions/ConnectTo"
             }, {
               "$ref" : "#/definitions/MoveToNode"
+            }, {
+              "$ref" : "#/definitions/CompressFileTask"
             }, {
               "$ref" : "#/definitions/DatabaseConnectionTask"
             }, {

--- a/ramls/workflow.json
+++ b/ramls/workflow.json
@@ -476,7 +476,12 @@
           "type" : "string"
         },
         "format" : {
-          "type" : "string"
+          "type" : "string",
+          "enum" : [ "BZIP2", "GZIP" ]
+        },
+        "container" : {
+          "type" : "string",
+          "enum" : [ "NONE", "TAR" ]
         },
         "identifier" : {
           "type" : "string"

--- a/src/main/java/org/folio/rest/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/CompressFileDelegate.java
@@ -1,0 +1,189 @@
+package org.folio.rest.delegate;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.camunda.bpm.model.bpmn.instance.FlowElement;
+import org.folio.rest.workflow.model.CompressFileTask;
+import org.h2.util.IOUtils;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+@Service
+@Scope("prototype")
+public class CompressFileDelegate extends AbstractWorkflowIODelegate {
+
+  private static final String ENCODING = "UTF8";
+  private static final int BLOCK_SIZE = 8192;
+
+  private static final String EXT_BZIP2 = ".bz2";
+  private static final String EXT_GZIP = ".gz";
+  private static final String EXT_TAR = ".tar";
+
+  private Expression source;
+
+  private Expression destination;
+
+  private Expression format;
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    long startTime = System.nanoTime();
+    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
+    String delegateName = bpmnModelElement.getName();
+
+    logger.info("{} started", delegateName);
+
+    String sourcePath = this.source.getValue(execution).toString();
+    String destinationPath = this.destination.getValue(execution).toString();
+    String formatType = this.format.getValue(execution).toString().toLowerCase();
+    String extension = "";
+    File sourceFile = new File(sourcePath);
+    File destinationFile = new File(destinationPath);
+
+    // see: https://commons.apache.org/proper/commons-compress/limitations.html
+    switch (formatType) {
+      case CompressorStreamFactory.BZIP2:
+        extension = EXT_BZIP2;
+        break;
+
+      case CompressorStreamFactory.GZIP:
+        extension = EXT_GZIP;
+        break;
+
+      default:
+        logger.info("{} is not a supported format", formatType);
+        formatType = null;
+        break;
+    }
+
+    if (sourceFile.exists()) {
+      if (!sourceFile.canRead()) {
+        logger.info("{} could not be read", sourceFile);
+        formatType = null;
+      }
+    } else {
+      logger.info("{} does not exist", sourceFile);
+      formatType = null;
+    }
+
+    if (formatType != null) {
+      if (destinationFile.isDirectory()) {
+        if (!destinationPath.endsWith(File.separator)) {
+          destinationPath += File.separator;
+        }
+
+        if (sourceFile.isDirectory()) {
+          destinationFile = new File(destinationPath + sourceFile.getName() + EXT_TAR + extension);
+        } else {
+          destinationFile = new File(destinationPath + sourceFile.getName() + extension);
+        }
+      }
+
+      if (sourceFile.isDirectory()) {
+        FileOutputStream outputFile = new FileOutputStream(destinationFile);
+        BufferedOutputStream output = new BufferedOutputStream(outputFile);
+
+        CompressorOutputStream compress = new CompressorStreamFactory()
+          .createCompressorOutputStream(formatType, output);
+
+        TarArchiveOutputStream tar = new TarArchiveOutputStream(compress, BLOCK_SIZE, ENCODING);
+
+        tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+        tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+
+        try {
+          addPaths(sourcePath, "", tar);
+
+          tar.finish();
+        } finally {
+          tar.close();
+          compress.close();
+          outputFile.close();
+        }
+      }
+      else {
+
+        try (
+          FileInputStream inputFile = new FileInputStream(sourceFile);
+          BufferedInputStream input = new BufferedInputStream(inputFile);
+          FileOutputStream outputFile = new FileOutputStream(destinationFile);
+          BufferedOutputStream output = new BufferedOutputStream(outputFile);
+          CompressorOutputStream compress = new CompressorStreamFactory()
+            .createCompressorOutputStream(formatType, output);
+          ) {
+            IOUtils.copy(input, compress);
+        }
+      }
+
+      logger.info("{} written to {} as {}", source, destination, format);
+    }
+
+    long endTime = System.nanoTime();
+    logger.info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+  }
+
+  public void setSource(Expression path) {
+    this.source = path;
+  }
+
+  public void setDestination(Expression path) {
+    this.destination = path;
+  }
+
+  public void setFormat(Expression op) {
+    this.format = op;
+  }
+
+  @Override
+  public Class<?> fromTask() {
+    return CompressFileTask.class;
+  }
+
+  private void addPaths(String path, String parentPath, TarArchiveOutputStream tar) throws IOException {
+    File file = new File(path);
+
+    setupEntryHeader(path, parentPath, tar, file);
+
+    if (file.isDirectory()) {
+      tar.closeArchiveEntry();
+
+      for (File f : file.listFiles()) {
+        addPaths(f.getAbsolutePath(), parentPath + file.getName() + File.separator, tar);
+      }
+    } else {
+      try (BufferedInputStream input = new BufferedInputStream(new FileInputStream(file))) {
+        IOUtils.copy(input, tar);
+      }
+
+      tar.closeArchiveEntry();
+    }
+  }
+
+  private void setupEntryHeader(String path, String parentPath, TarArchiveOutputStream tar, File file) throws IOException {
+    Path filePath = Path.of(path);
+    TarArchiveEntry entry = new TarArchiveEntry(file, parentPath + file.getName());
+
+    if (file.isFile()) {
+      entry.setSize(Files.size(Paths.get(path)));
+    }
+
+    entry.setModTime(Files.getLastModifiedTime(filePath).toMillis());
+
+    tar.putArchiveEntry(entry);
+  }
+
+}

--- a/src/main/java/org/folio/rest/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/CompressFileDelegate.java
@@ -136,16 +136,16 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
     logger.info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
   }
 
-  public void setSource(Expression path) {
-    this.source = path;
+  public void setSource(Expression source) {
+    this.source = source;
   }
 
-  public void setDestination(Expression path) {
-    this.destination = path;
+  public void setDestination(Expression destination) {
+    this.destination = destination;
   }
 
-  public void setFormat(Expression op) {
-    this.format = op;
+  public void setFormat(Expression format) {
+    this.format = format;
   }
 
   @Override


### PR DESCRIPTION
This adds support for `.gz`, `.tar.gz`, `.bz2`, and `.tar.bz2`.
Additional formats are possible but require extra work that is left for later.

The task `CompressFileTask` accepts these parameters:
- source: the source file or directory.
- destination: the destination directory (not the destination file).
- format: currently only `GZIP` and `BZIP2`.
- container: currently only `NONE` and `TAR`.

When the source is a file, it will be compressed (`example.txt` would become `example.txt.gz` for a `GZIP` format).
When the source is a directory and `container` is set to `TAR`, then the directory will be tarballed and then compressed (`examples/` would become `examples.tar.gz` for a `GZIP` format).

The Apache Commons dependency for the compression library is explicitly added into the pom file.
Without this explicit addition, a python related dependency ends up getting pulled in instead.

resolves #133