### PR TITLE
[Issue 124] Purchase Order Workflow: Add email task to end of purchase order workflow.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,19 @@
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
       <version>2.1.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mailapi</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+   <dependency>
+     <groupId>com.sun.mail</groupId>
+     <artifactId>javax.mail</artifactId>
+     <version>1.6.2</version>
+   </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -242,7 +254,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
     </dependency>
 
     <dependency>

--- a/ramls/conditionalgateway.json
+++ b/ramls/conditionalgateway.json
@@ -728,6 +728,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/ramls/emailtask.json
+++ b/ramls/emailtask.json
@@ -61,6 +61,9 @@
       "type" : "string",
       "minLength" : 2
     },
+    "mailMarkup" : {
+      "type" : "string"
+    },
     "attachmentPath" : {
       "type" : "string"
     },

--- a/ramls/eventsubprocess.json
+++ b/ramls/eventsubprocess.json
@@ -714,6 +714,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/ramls/movetonode.json
+++ b/ramls/movetonode.json
@@ -717,6 +717,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/ramls/parallelgateway.json
+++ b/ramls/parallelgateway.json
@@ -714,6 +714,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/ramls/subprocess.json
+++ b/ramls/subprocess.json
@@ -730,6 +730,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/ramls/workflow.json
+++ b/ramls/workflow.json
@@ -741,6 +741,9 @@
           "type" : "string",
           "minLength" : 2
         },
+        "mailMarkup" : {
+          "type" : "string"
+        },
         "attachmentPath" : {
           "type" : "string"
         },

--- a/src/main/java/org/folio/rest/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/EmailDelegate.java
@@ -41,6 +41,8 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
   private Expression mailText;
 
+  private Expression mailMarkup;
+
   private Expression attachmentPath;
 
   @Override
@@ -53,21 +55,26 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
     String subjectTemplate = this.mailSubject.getValue(execution).toString();
     String textTemplate = this.mailText.getValue(execution).toString();
-
-    Map<String, Object> inputs = getInputs(execution);
-
-    Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+    String markupTemplate = Objects.nonNull(this.mailMarkup) ? this.mailMarkup.getValue(execution).toString() : "";
+    String mailToTemplate = this.mailTo.getValue(execution).toString();
+    String mailFromTemplate = this.mailFrom.getValue(execution).toString();
 
     StringTemplateLoader stringLoader = new StringTemplateLoader();
     stringLoader.putTemplate("subject", subjectTemplate);
     stringLoader.putTemplate("text", textTemplate);
+    stringLoader.putTemplate("markup", markupTemplate);
+    stringLoader.putTemplate("mailFrom", mailToTemplate);
+    stringLoader.putTemplate("mailTo", mailFromTemplate);
+
+    Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
     cfg.setTemplateLoader(stringLoader);
 
+    Map<String, Object> inputs = getInputs(execution);
     String subject = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("subject"), inputs);
-    String text = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("text"), inputs);
-
-    String to = this.mailTo.getValue(execution).toString();
-    String from = this.mailFrom.getValue(execution).toString();
+    String plainText = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("text"), inputs);
+    String htmlMarkup = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("markup"), inputs);
+    String to = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailTo"), inputs);
+    String from = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailFrom"), inputs);
 
     Optional<String> cc = Objects.nonNull(this.mailCc) ? Optional.of(this.mailCc.getValue(execution).toString()) : Optional.empty();
     Optional<String> bcc = Objects.nonNull(this.mailBcc) ? Optional.of(this.mailBcc.getValue(execution).toString()) : Optional.empty();
@@ -83,7 +90,16 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
               message.addTo(ct);
             }
             message.setSubject(subject);
-            message.setText(text, true);
+
+            if (Objects.nonNull(mailMarkup)) {
+              if (plainText.isEmpty()) {
+                message.setText(htmlMarkup, true);
+              } else {
+                message.setText(plainText, htmlMarkup);
+              }
+            } else {
+              message.setText(plainText, false);
+            }
 
             if (cc.isPresent()) {
               for (String ccc : cc.get().split(",")) {
@@ -136,6 +152,10 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
   public void setMailText(Expression mailText) {
     this.mailText = mailText;
+  }
+
+  public void setMailMarkup(Expression mailMarkup) {
+    this.mailMarkup = mailMarkup;
   }
 
   public void setAttachmentPath(Expression attachmentPath) {


### PR DESCRIPTION
Utilize dynamic and configurable file path.
The path fields need to be template-able.

Properly handle HTML Markup and Plain Text Markup when sending e-mails.
Add `markup`/`mailMarkup` as an optional field (making it backwards compatible with existing workflows).

Fix dependencies where older mailapi is being included.

relates TAMULib/fw-registry#124