### PR TITLE
mod-workflow issue 77: Workflow History API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <camunda.version>7.12.0</camunda.version>
-    <camunda.spring.boot.version>3.4.0</camunda.spring.boot.version>
+    <camunda.spring.boot.version>3.4.4</camunda.spring.boot.version>
   </properties>
 
   <build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,7 +64,7 @@ spring:
   thymeleaf:
     mode: TEXT
     suffix: .sql
-  jersey.application-path: camunda
+  jersey.application-path: rest
 
 camunda:
   bpm:


### PR DESCRIPTION
Update spring boot version in pom.
Replace `camunda` with `rest` to be less redundant and slightly more consistent with Camunda's documentation.

relates TAMULib/mod-workflow/issues/77