### PR TITLE
Check for existence of output variable

### DIFF
--- a/src/main/java/org/folio/rest/delegate/AbstractDatabaseOutputDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/AbstractDatabaseOutputDelegate.java
@@ -1,6 +1,6 @@
 package org.folio.rest.delegate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Objects;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
@@ -8,6 +8,10 @@ import org.folio.rest.service.DatabaseConnectionService;
 import org.folio.rest.workflow.model.EmbeddedVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+// This class probably should be called AbstractDatabaseIODelegate to align with AbstractWorkflowIODelegate.
+// Deferring refactor at this time in case it may cause breaking changes.
 public abstract class AbstractDatabaseOutputDelegate extends AbstractWorkflowInputDelegate implements Output {
 
   Expression designation;
@@ -19,6 +23,11 @@ public abstract class AbstractDatabaseOutputDelegate extends AbstractWorkflowInp
 
   public void setDesignation(Expression designation) {
     this.designation = designation;
+  }
+
+  public Boolean hasOutputVariable(DelegateExecution execution) {
+    return Objects.nonNull(outputVariable) &&
+        Objects.nonNull(outputVariable.getValue(execution));
   }
 
   public EmbeddedVariable getOutputVariable(DelegateExecution execution) throws JsonProcessingException {

--- a/src/main/java/org/folio/rest/delegate/DatabaseQueryDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/DatabaseQueryDelegate.java
@@ -95,7 +95,11 @@ public class DatabaseQueryDelegate extends AbstractDatabaseOutputDelegate {
         }
 
         if (resultOp instanceof FileResultOp) {
-          setOutput(execution, count);
+          if (hasOutputVariable(execution)) {
+            setOutput(execution, count);
+          } else {
+            logger.info("{} did not specify output variable for result count", delegateName);
+          }
         }
 
         resultOp.finish();


### PR DESCRIPTION
Only applicable to concrete class that extend output interface that do not require the output variable from the component persistent definition. In this case the AbstractDatabaseOutputDelegate implements Output but the DatabaseQueryTask does not require output variable for all types of its operations.