### PR TITLE
Hot fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>workflow-components</artifactId>
-      <version>1.1.7</version>
+      <version>1.1.8-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>workflow-components</artifactId>
-      <version>1.1.8-SNAPSHOT</version>
+      <version>1.1.7</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/rest/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/EmailDelegate.java
@@ -119,7 +119,14 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
           }
         }
 
-        if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
+        // TODO: This is a hot fix to address an issue with the workflows no attaching emails
+
+        //if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
+        if (attachmentPath.isPresent()) {
+
+          logger.info("includeAttachment.isPresent() = {}", includeAttachment.isPresent());
+          logger.info("Boolean.parseBoolean(includeAttachment.get()) = {}", Boolean.parseBoolean(includeAttachment.get()));
+
           File attachment = new File(attachmentPath.get());
           if (attachment.exists() && attachment.isFile()) {
             message.addAttachment(attachment.getName(), attachment);

--- a/src/main/java/org/folio/rest/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/EmailDelegate.java
@@ -133,6 +133,8 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
           } else {
             logger.info("{} does not exist", attachmentPath.get());
           }
+        } else {
+          logger.info("No attachment required");
         }
       }
     };

--- a/src/main/java/org/folio/rest/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/EmailDelegate.java
@@ -121,10 +121,10 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
         // TODO: This is a hot fix to address an issue with the workflows no attaching emails
 
-        if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
-        
-          logger.info("includeAttachment.isPresent() = {}", includeAttachment.isPresent());
-          logger.info("Boolean.parseBoolean(includeAttachment.get()) = {}", Boolean.parseBoolean(includeAttachment.get()));
+        // if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
+        if (attachmentPath.isPresent()) {
+          // logger.info("includeAttachment.isPresent() = {}", includeAttachment.isPresent());
+          // logger.info("Boolean.parseBoolean(includeAttachment.get()) = {}", Boolean.parseBoolean(includeAttachment.get()));
 
           File attachment = new File(attachmentPath.get());
           if (attachment.exists() && attachment.isFile()) {

--- a/src/main/java/org/folio/rest/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/EmailDelegate.java
@@ -121,9 +121,8 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
         // TODO: This is a hot fix to address an issue with the workflows no attaching emails
 
-        //if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
-        if (attachmentPath.isPresent()) {
-
+        if (includeAttachment.isPresent() && Boolean.parseBoolean(includeAttachment.get()) && attachmentPath.isPresent()) {
+        
           logger.info("includeAttachment.isPresent() = {}", includeAttachment.isPresent());
           logger.info("Boolean.parseBoolean(includeAttachment.get()) = {}", Boolean.parseBoolean(includeAttachment.get()));
 


### PR DESCRIPTION
This addresses the email attachment regression by introducing a new regression that causes emails to always attach the file referenced by the attachmentPath.

This additional regression has been recorded with [this issue](https://github.com/TAMULib/mod-camunda/issues/215)