### PR TITLE
Issue 302: Switch from Nashorn to GraalVM for Javascript execution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,12 @@
       <version>22.3.3</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js-scriptengine</artifactId>
+      <version>22.3.3</version>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,12 @@
       <version>1.10.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
+      <version>22.3.3</version>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/src/main/resources/META-INF/bpm-platform.xml
+++ b/src/main/resources/META-INF/bpm-platform.xml
@@ -3,7 +3,7 @@
     <properties>
       <property name="waitTimeInMillis">15000</property>
       <property name="lockTimeInMillis">900000</property>
-      <property name="javascriptScriptEngine">graal.js</property>
+      <property name="javascriptScriptEngine">Graal.js</property>
     </properties>
   </job-acquisition>
 </job-executor>

--- a/src/main/resources/META-INF/bpm-platform.xml
+++ b/src/main/resources/META-INF/bpm-platform.xml
@@ -3,6 +3,7 @@
     <properties>
       <property name="waitTimeInMillis">15000</property>
       <property name="lockTimeInMillis">900000</property>
+      <property name="javascriptScriptEngine">graal.js</property>
     </properties>
   </job-acquisition>
 </job-executor>


### PR DESCRIPTION
resolves TAMULib/fw-registry#302

In addition to information provided on the issue, this dependency is also required:
```
    <dependency>
      <groupId>org.graalvm.js</groupId>
      <artifactId>js-scriptengine</artifactId>
      <version>22.3.3</version>
    </dependency>
```

The configuration file appears to be case sensitive.
Use `Graal.js` with an upper case `G` rather than a lower case `g`.

    
The following warning is observed:
```
[engine] WARNING: The polyglot context is using an implementation that does not support runtime compilation.
The guest application code will therefore be executed in interpreted mode only.
Execution only in interpreted mode will strongly impact the guest application performance.
For more information on using GraalVM see https://www.graalvm.org/java/quickstart/.
To disable this warning the '--engine.WarnInterpreterOnly=false' option or use the '-Dpolyglot.engine.WarnInterpreterOnly=false' system property.
[engine] WARNING: The polyglot context is using an implementation that does not support runtime compilation.
The guest application code will therefore be executed in interpreted mode only.
Execution only in interpreted mode will strongly impact the guest application performance.
For more information on using GraalVM see https://www.graalvm.org/java/quickstart/.
To disable this warning the '--engine.WarnInterpreterOnly=false' option or use the '-Dpolyglot.engine.WarnInterpreterOnly=false' system property.
```

When JS processing errors happen, this gets shown:
```
Execution of JMS message listener failed, and no ErrorHandler has been set.
```

see: https://forum.camunda.io/t/console-filling-with-graalvm-warnings-when-using-in-process-scripting/31812/2
see: https://docs.camunda.org/manual/7.19/user-guide/process-engine/scripting/#custom-scriptengineresolver