### PR TITLE
Issue 222: Java 17 and related upgrades.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ hs_err_pid*
 .DS_Store
 
 .vagrant/
+dependency-reduced-pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ USER root
 RUN apk upgrade --no-cache
 USER folio
 
-ENV VERTICLE_FILE mod-camunda-fat.jar
+ENV VERTICLE_FILE mod-camunda.jar
 
 # Set the location of the verticles
 ENV VERTICLE_HOME /usr/verticles
 
 # Copy your fat jar to the container
-COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
+COPY target/fat/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 9000

--- a/docker/build_and_run/Dockerfile
+++ b/docker/build_and_run/Dockerfile
@@ -1,0 +1,39 @@
+# build base image
+FROM openjdk:17-slim as maven
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y maven && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# copy required files
+COPY ./pom.xml ./pom.xml
+COPY ./src ./src
+
+# build
+RUN mvn package
+
+# final base image
+FROM openjdk:17-slim
+
+# Upgrade to latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y maven && \
+    apt-get clean
+
+# set deployment directory
+WORKDIR /mod-camunda
+
+# copy over the built artifact from the maven image
+COPY --from=maven /target/mod-camunda*.jar ./mod-camunda.jar
+
+# environment
+ENV SERVER_PORT='9000'
+
+# expose port
+EXPOSE ${SERVER_PORT}
+
+# run java command
+CMD java -jar -Xmx4096m ./mod-camunda.jar

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -73,6 +73,32 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.SpringOkapiModule</mainClass>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>org.folio.inventory.Launcher</Main-Class>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+              <artifactSet />
+              <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>
           </execution>
         </executions>
@@ -154,7 +180,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>spring-tenant</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.5</version>
     </dependency>
 
     <dependency>
@@ -183,7 +209,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-freemarker</artifactId>
@@ -202,21 +228,18 @@
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter</artifactId>
-      <version>${camunda.spring.boot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter-webapp</artifactId>
-      <version>${camunda.spring.boot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
-      <version>${camunda.spring.boot.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.camunda.template-engines</groupId>
       <artifactId>camunda-template-engines-freemarker</artifactId>
@@ -236,7 +259,7 @@
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-plugin-spin</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
@@ -287,7 +310,7 @@
       <artifactId>jython-standalone</artifactId>
       <version>2.7.3</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jms</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
                 </transformer>
               </transformers>
               <artifactSet />
-              <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
+              <outputFile>${project.build.directory}/fat/${project.artifactId}.jar</outputFile>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/org/folio/rest/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/service/CamundaApiService.java
@@ -9,15 +9,11 @@ import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.folio.rest.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.exception.WorkflowAlreadyDeactivatedException;
 import org.folio.rest.workflow.model.Workflow;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CamundaApiService {
-
-  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
   @Autowired
   private BpmnModelFactory bpmnModelFactory;


### PR DESCRIPTION
resolves #222

The Dockerfiles ended up needing to be upgraded to Java 17.
While making this change, switch to the official Folio style/practices of the Dockerfile.
Create a sub-directory called `docker` and place the build and run Dockerfile there.

The `maven-shade-plugin` plugin is brought in to conform with the Folio Dockerfile build practices. To prevent conflicts, a sub-directory called `fat/` is created to store the file generated by the shade plugin.

Some plugins or dependencies are updated in the POM file.

Minor syntax fixes are performed.