### PR TITLE
Descriptors directory is required to compile in the build and run Dockerfile.

### DIFF
--- a/docker/build_and_run/Dockerfile
+++ b/docker/build_and_run/Dockerfile
@@ -7,9 +7,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN mkdir /mod-camunda
+WORKDIR /mod-camunda
+
 # copy required files
 COPY ./pom.xml ./pom.xml
 COPY ./src ./src
+COPY ./descriptors ./descriptors
 
 # build
 RUN mvn package
@@ -27,7 +31,7 @@ RUN apt-get update && \
 WORKDIR /mod-camunda
 
 # copy over the built artifact from the maven image
-COPY --from=maven /target/mod-camunda*.jar ./mod-camunda.jar
+COPY --from=maven /mod-camunda/target/mod-camunda*.jar ./mod-camunda.jar
 
 # environment
 ENV SERVER_PORT='9000'


### PR DESCRIPTION
The addition of the `/descriptors` did not take into account the build and run Dockerfile.

For safety reasons, use a sub-directory for building rather than building at the file system root.