### PR TITLE
Prevent resource leaks in FileDelegate when using BufferedReader.

### DIFF
--- a/src/main/java/org/folio/rest/delegate/FileDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/FileDelegate.java
@@ -75,24 +75,26 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
         break;
       case LINE_COUNT:
         if (file.exists()) {
-          BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8);
-          long lineCount = reader.lines().count();
-          reader.close();
-          setOutput(execution, lineCount);
-          logger.info("{} read", filePath);
+          try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8)) {
+            long lineCount = reader.lines().count();
+            reader.close();
+            setOutput(execution, lineCount);
+            logger.info("{} read", filePath);
+          }
         } else {
           logger.info("{} does not exist", filePath);
         }
         break;
       case READ_LINE:
         if (file.exists() && line > 0) {
-          BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8);
-          int lineCount = 0;
-          String currerntLine = "";
-          while ((currerntLine = reader.readLine()) != null && (++lineCount) < line) {}
-          reader.close();
-          setOutput(execution, currerntLine);
-          logger.info("{} read", filePath);
+          try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8)) {
+            int lineCount = 0;
+            String currerntLine = "";
+            while ((currerntLine = reader.readLine()) != null && (++lineCount) < line) {}
+            reader.close();
+            setOutput(execution, currerntLine);
+            logger.info("{} read", filePath);
+          }
         } else {
           logger.info("{} does not exist", filePath);
         }


### PR DESCRIPTION
Implement a suggestion by @julianladisch here:
- https://github.com/folio-org/mod-camunda/pull/82

"Using try-with-resources prevents resource leaks..."