### PR TITLE
Add support for Python and Ruby via the dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,13 +245,49 @@
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
-      <version>23.0.3</version>
+      <version>23.0.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.python</groupId>
+      <artifactId>python-language</artifactId>
+      <version>23.1.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.python</groupId>
+      <artifactId>python-resources</artifactId>
+      <version>23.1.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.ruby</groupId>
+      <artifactId>ruby-language</artifactId>
+      <version>23.1.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.ruby</groupId>
+      <artifactId>ruby-resources</artifactId>
+      <version>23.1.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>9.4.7.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
       <version>23.1.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>polyglot</artifactId>
+      <version>23.1.3</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/rest/camunda/utility/ScriptEngineUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/ScriptEngineUtility.java
@@ -1,0 +1,37 @@
+package org.folio.rest.camunda.utility;
+
+import org.graalvm.shadowed.org.json.JSONObject;
+
+/**
+ * Provide utility functions specifically needed for scripting engines.
+ */
+public class ScriptEngineUtility {
+
+    /**
+     * Decode a JSON string into a JSONObject.
+     *
+     * This is required by several of the scripting engines, such as engine.py.
+     *
+     * @param json
+     *   The JSON string to decode.
+     *
+     * @return
+     *   A generated JSON object, containing the decoded JSON string.
+     */
+    public JSONObject decodeJson(String json) {
+      return new JSONObject(json);
+    }
+
+    /**
+     * Encode a JSONObject into a JSON string.
+     *
+     * @param json
+     *   The JSONObject to encode.
+     *
+     * @return
+     *   A String containing the encoded JSON data.
+     */
+    public String encodeJson(JSONObject json) {
+      return json.toString(2);
+    }
+}

--- a/src/main/resources/scripts/engine.groovy
+++ b/src/main/resources/scripts/engine.groovy
@@ -1,4 +1,4 @@
-import org.folio.rest.utility.ScriptEngineUtility
+import org.folio.rest.camunda.utility.ScriptEngineUtility
 
 def %s(String inArgs) {
   def scriptEngineUtility = new ScriptEngineUtility();

--- a/src/main/resources/scripts/engine.java
+++ b/src/main/resources/scripts/engine.java
@@ -1,5 +1,5 @@
-import org.camunda.bpm.engine.impl.util.json.JSONObject;
-import org.folio.rest.utility.ScriptEngineUtility;
+import org.graalvm.shadowed.org.json.JSONObject;
+import org.folio.rest.camunda.utility.ScriptEngineUtility;
 
 public String %s(String inArgs) {
   ScriptEngineUtility scriptEngineUtility = new ScriptEngineUtility();

--- a/src/main/resources/scripts/engine.pl
+++ b/src/main/resources/scripts/engine.pl
@@ -1,5 +1,5 @@
 use JSON;
-use org.folio.rest.utility.ScriptEngineUtility;
+use org.folio.rest.camunda.utility.ScriptEngineUtility;
 
 sub %s($) {
   my ($inArgs) = @_;

--- a/src/main/resources/scripts/engine.py
+++ b/src/main/resources/scripts/engine.py
@@ -1,5 +1,5 @@
 import json
-import org.folio.rest.utility.ScriptEngineUtility;
+import org.folio.rest.camunda.utility.ScriptEngineUtility;
 
 def %s(inArgs):
   scriptEngineUtility = org.folio.rest.utility.ScriptEngineUtility();

--- a/src/main/resources/scripts/engine.rb
+++ b/src/main/resources/scripts/engine.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'use org.folio.rest.utility.ScriptEngineUtility'
+require 'use org.folio.rest.camunda.utility.ScriptEngineUtility'
 
 def %s(inArgs)
   scriptEngineUtility = ScriptEngineUtility();


### PR DESCRIPTION
This also adds polyglot which may or may not be needed.
Further investigation is needed for the polyglot and if it is determined to be not needed then it should be removed.

Add back the scripting engine helper and fix the engine scripts paths.

The scripting engine helper is required by these engines.
The path also now needs to have `camunda` in it.