### PR TITLE
De-serialized a stringified JSON code for the ScriptTask.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
+++ b/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
@@ -1,6 +1,7 @@
 package org.folio.rest.camunda.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.camunda.service.CamundaApiService;
 import org.folio.rest.workflow.model.Workflow;
@@ -26,7 +27,7 @@ public class WorkflowController {
 
   @PostMapping(value = {"/activate", "/activate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow activateWorkflow(@RequestBody Workflow workflow, @TenantHeader String tenant)
-      throws WorkflowAlreadyActiveException {
+      throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
     log.debug("Activating Workflow: {}", workflow == null ? null : workflow.getId());
     return camundaApiService.deployWorkflow(workflow, tenant);
   }

--- a/src/main/java/org/folio/rest/camunda/exception/ScriptTaskDeserializeCodeFailure.java
+++ b/src/main/java/org/folio/rest/camunda/exception/ScriptTaskDeserializeCodeFailure.java
@@ -1,0 +1,17 @@
+package org.folio.rest.camunda.exception;
+
+public class ScriptTaskDeserializeCodeFailure extends Exception {
+
+  private static final long serialVersionUID = -6270663785866339965L;
+
+  private static final String MESSAGE = "Failed to De-serialize code for ScriptTask %s.";
+
+  public ScriptTaskDeserializeCodeFailure(String scriptTaskUuid) {
+    super(String.format(MESSAGE, scriptTaskUuid));
+  }
+
+  public ScriptTaskDeserializeCodeFailure(String scriptTaskUuid, Exception e) {
+    super(String.format(MESSAGE, scriptTaskUuid), e);
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -6,6 +6,7 @@ import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.model.Workflow;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ public class CamundaApiService {
   @Autowired
   private BpmnModelFactory bpmnModelFactory;
 
-  public Workflow deployWorkflow(Workflow workflow, String tenant) throws WorkflowAlreadyActiveException {
+  public Workflow deployWorkflow(Workflow workflow, String tenant) throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
     if (workflow.isActive()) {
       throw new WorkflowAlreadyActiveException(workflow.getId());
     }

--- a/src/test/java/org/folio/rest/camunda/exception/ScriptTaskDeserializeCodeFailureTest.java
+++ b/src/test/java/org/folio/rest/camunda/exception/ScriptTaskDeserializeCodeFailureTest.java
@@ -1,0 +1,35 @@
+package org.folio.rest.camunda.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScriptTaskDeserializeCodeFailureTest {
+
+  @Test
+  void scriptEngineLoadFailedWorksTest() throws IOException {
+      ScriptTaskDeserializeCodeFailure exception = Assertions.assertThrows(ScriptTaskDeserializeCodeFailure.class, () -> {
+      throw new ScriptTaskDeserializeCodeFailure(UUID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+  @Test
+  void scriptEngineLoadFailedWorksWithParameterTest() throws IOException {
+      ScriptTaskDeserializeCodeFailure exception = Assertions.assertThrows(ScriptTaskDeserializeCodeFailure.class, () -> {
+      throw new ScriptTaskDeserializeCodeFailure(UUID, new RuntimeException());
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+}


### PR DESCRIPTION
The `ScriptTask` should be serialized using `JSON.stringify()` in the Javascript. 

Once this is done the server can now safely de-serialize the code.

The code no longer needs to have the newlines altered when added to the `code` property value in the fw-cli and similar clients.

Such code now requires the `JSON.stringify()` or something similar when adding it to the `code` property value.