### PR TITLE
TLS escapes isolation under Linux so add a Static Mock to constrain the TLS use case.

### DIFF
--- a/src/test/java/org/folio/rest/camunda/jms/EventConsumerTest.java
+++ b/src/test/java/org/folio/rest/camunda/jms/EventConsumerTest.java
@@ -5,22 +5,23 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
-import java.util.HashMap;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.stream.Stream;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.folio.spring.messaging.model.Event;
+import org.folio.spring.tenant.storage.ThreadLocalStorage;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,16 +51,18 @@ class EventConsumerTest {
   @MethodSource("eventStream")
   @SuppressWarnings("unchecked")
   void testReceive(Event event) throws JsonProcessingException {
-    doReturn(processInstance).when(messageCorrelationBuilder).correlateStartMessage();
-    doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).setVariables(anyMap());
-    doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).tenantId(anyString());
-    doReturn(messageCorrelationBuilder).when(runtimeService).createMessageCorrelation(anyString());
+    try (MockedStatic<ThreadLocalStorage> utility = Mockito.mockStatic(ThreadLocalStorage.class)) {
+      doReturn(processInstance).when(messageCorrelationBuilder).correlateStartMessage();
+      doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).setVariables(anyMap());
+      doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).tenantId(anyString());
+      doReturn(messageCorrelationBuilder).when(runtimeService).createMessageCorrelation(anyString());
 
-    doReturn(new HashMap<String, Object>()).when(objectMapper).convertValue(any(JsonNode.class), any(TypeReference.class));
+      doReturn(new HashMap<String, Object>()).when(objectMapper).convertValue(any(JsonNode.class), any(TypeReference.class));
 
-    eventConsumer.receive(event);
+      eventConsumer.receive(event);
 
-    Mockito.verify(messageCorrelationBuilder).correlateStartMessage();
+      Mockito.verify(messageCorrelationBuilder).correlateStartMessage();
+    }
   }
 
   static Stream<Event> eventStream() {


### PR DESCRIPTION
On Linux I get:
```
WorkflowControllerAdviceTest.exceptionsThrownForActivateWorkflowTest(Exception, String, int)[1] » IllegalState Failed to load ApplicationContext for [WebMergedContextConfiguration@2e79cc2e testClass = org.folio.rest.camunda.controller.advice.WorkflowControllerAdviceTest, locations = [], classes = [org.folio.rest.camunda.SpringOkapiModule], contextInitializerClasses = [], activeProfiles = [], propertySourceDescriptors = [], propertySourceProperties = ["org.springframework.boot.test.context.SpringBootTestContextBootstrapper=true"], contextCustomizers = [[ImportsContextCustomizer@2d4d2d55 key = [org.springframework.boot.test.autoconfigure.web.servlet.MockMvcWebDriverAutoConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcAutoConfiguration, org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration, org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcSecurityConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcWebClientAutoConfiguration, org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientAutoConfiguration]], org.springframework.boot.test.context.filter.ExcludeFilterContextCustomizer@54e18a46, org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory$DuplicateJsonObjectContextCustomizer@666b91db, org.springframework.boot.test.mock.mockito.MockitoContextCustomizer@0, org.springframework.boot.test.web.client.TestRestTemplateContextCustomizer@3c87b7ef, org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizer@6e71c9dc, org.springframework.boot.test.autoconfigure.actuate.observability.ObservabilityContextCustomizerFactory$DisableObservabilityContextCustomizer@1f, org.springframework.boot.test.autoconfigure.properties.PropertyMappingContextCustomizer@4b3fa0b3, org.springframework.boot.test.autoconfigure.web.servlet.WebDriverContextCustomizer@7097d921, org.springframework.boot.test.context.SpringBootTestAnnotation@8061ab26], resourceBasePath = "src/main/webapp", contextLoader = org.springframework.boot.test.context.SpringBootContextLoader, parent = null]
```

That test is not touched in this branch and so this is some sort of isolation problem.

Investigation shows that it happens under Linux but not Windows.
The Thread Local Storage (TLS) appears to be the culprit.

Add a static mock wrapper around the TLS use case to prevent the escaping of test isolation.