### PR TITLE
[Issue #257]: Encrypt passwords in BPMN, decrypt with expression

### DIFF
--- a/src/main/java/org/folio/rest/camunda/controller/advice/WorkflowControllerAdvice.java
+++ b/src/main/java/org/folio/rest/camunda/controller/advice/WorkflowControllerAdvice.java
@@ -2,6 +2,7 @@ package org.folio.rest.camunda.controller.advice;
 
 import lombok.extern.slf4j.Slf4j;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
+import org.folio.rest.workflow.exception.SecureOperationException;
 import org.folio.spring.web.model.response.ResponseErrors;
 import org.folio.spring.web.utility.ErrorUtility;
 import org.springframework.http.HttpStatus;
@@ -19,4 +20,12 @@ public class WorkflowControllerAdvice {
     log.debug(exception.getMessage(), exception);
     return ErrorUtility.buildError(exception, HttpStatus.BAD_REQUEST);
   }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(SecureOperationException.class)
+  public ResponseErrors handleSecureOperationException(SecureOperationException exception) {
+    log.error(exception.getMessage(), exception);
+    return ErrorUtility.buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
 }


### PR DESCRIPTION
Requires https://github.com/TAMULib/mod-workflow/pull/136

This is incomplete work. However plain text passwords are no longer in BPMN.xml downloadable from Camunda Dashboard and no longer persisting in mod-workflow database.

Plain text passwords are still being exposed in the Camunda Dashboard for RequestTask input variables. All of these just happen to be from fw-registry workflows okapi login, a duplicate node. The asSecure flag added to EmbeddedVariable is to inform the custom Java Delegates implementing Input with getInputs decrypting those that are asSecure while Output implementation of setOutput encrypting those that are asSecure before setting as LOCAL or PROCESS variable.