### PR TITLE
Update data-import-processing-core version to 4.3.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.3.1</version>
+      <version>4.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>


### PR DESCRIPTION
This resolves the original problem described in TAMULib/fw-registry#397.

Upon upgrading to Poppy, the mapping functionality provided by external FOLIO modules does not work because the `SET_CONTRIBUTOR_TYPE_ID_BY_CODE_OR_NAME` and `TRIM_PUNCTUATION` are out of date or missing.

The `author.` is from the `100.e` from the MARC record should now be converted.
The normalization functions will strip out the punctuation, like the period `.`, and then map the name `author` into a matching UUID.

The error `22 Unprocessable Entity: "{"errors":[{"message":"must match \"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$\"","type":"1","code":"javax.validation.constraints.Pattern.message","parameters":[{"key":"contributors[0].contributorTypeId","value":"author."}]}]}` (which does not come from mod-camunda, but instead some other module via OKAPI) no longer happens.

see: https://github.com/folio-org/data-import-processing-core/blob/42b8d49510f64694a5094a2e353af45b258ee1cf/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java#L330
see: https://github.com/folio-org/data-import-processing-core/blob/42b8d49510f64694a5094a2e353af45b258ee1cf/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java#L108