### PR TITLE
Revert Subject-Sources and Subject-Types addition for future planning.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/utility/MappingParametersType.java
+++ b/src/main/java/org/folio/rest/camunda/utility/MappingParametersType.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.folio.AlternativeTitleType;
 import org.folio.Alternativetitletypes;
 import org.folio.CallNumberType;
@@ -56,10 +55,6 @@ import org.folio.StatisticalCode;
 import org.folio.StatisticalCodeType;
 import org.folio.Statisticalcodes;
 import org.folio.Statisticalcodetypes;
-import org.folio.SubjectSource;
-import org.folio.SubjectSources;
-import org.folio.SubjectType;
-import org.folio.SubjectTypes;
 import org.folio.rest.jaxrs.model.MarcFieldProtectionSetting;
 
 /**
@@ -153,13 +148,7 @@ public enum MappingParametersType {
   STATISTICAL_CODE_TYPES(StatisticalCodeType.class, Statisticalcodetypes.class, "/statistical-code-types"),
 
   /** Mapping type for statistical codes. */
-  STATISTICAL_CODES(StatisticalCode.class, Statisticalcodes.class, "/statistical-codes"),
-
-  /** Mapping type for subject sources. */
-  SUBJECT_SOURCES(SubjectSource.class, SubjectSources.class, "/subject-sources"),
-
-  /** Mapping type for subject types. */
-  SUBJECT_TYPES(SubjectType.class, SubjectTypes.class, "/subject-types");
+  STATISTICAL_CODES(StatisticalCode.class, Statisticalcodes.class, "/statistical-codes");
 
   /** The specific parameter type class for this mapping type. */
   private final Class<?> parametersType;
@@ -252,6 +241,7 @@ public enum MappingParametersType {
   protected static class ParametersTypeLookupException extends RuntimeException {
 
     private static final long serialVersionUID = -9152302641261345898L;
+
     /**
      * Template for generating detailed error messages about parameters type lookup
      * failures.

--- a/src/main/java/org/folio/rest/camunda/utility/MappingParametersUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/MappingParametersUtility.java
@@ -54,11 +54,8 @@ import org.folio.StatisticalCode;
 import org.folio.StatisticalCodeType;
 import org.folio.Statisticalcodes;
 import org.folio.Statisticalcodetypes;
-import org.folio.SubjectSource;
-import org.folio.SubjectSources;
-import org.folio.SubjectType;
-import org.folio.SubjectTypes;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.camunda.utility.MappingParametersType.ParametersTypeLookupException;
 import org.folio.rest.jaxrs.model.MarcFieldProtectionSetting;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
@@ -187,9 +184,7 @@ public class MappingParametersUtility {
       .withMaterialTypes(((Materialtypes) getParameters(restTemplate, Mtype.class)).getMtypes())
       .withNatureOfContentTerms(((Natureofcontentterms) getParameters(restTemplate, NatureOfContentTerm.class)).getNatureOfContentTerms())
       .withStatisticalCodes(((Statisticalcodes) getParameters(restTemplate, StatisticalCode.class)).getStatisticalCodes())
-      .withStatisticalCodeTypes(((Statisticalcodetypes) getParameters(restTemplate, StatisticalCodeType.class)).getStatisticalCodeTypes())
-      .withSubjectSources(((SubjectSources) getParameters(restTemplate, SubjectSource.class)).getSubjectSources())
-      .withSubjectTypes(((SubjectTypes) getParameters(restTemplate, SubjectType.class)).getSubjectTypes());
+      .withStatisticalCodeTypes(((Statisticalcodetypes) getParameters(restTemplate, StatisticalCodeType.class)).getStatisticalCodeTypes());
   }
 
   /**
@@ -240,6 +235,7 @@ public class MappingParametersUtility {
   private static class ParametersRetrievalException extends RuntimeException {
 
     private static final long serialVersionUID = 717934762826254910L;
+
     /**
      * Template for generating detailed error messages about parameter retrieval
      * failures.

--- a/src/test/java/org/folio/rest/camunda/utility/MappingParametersTypeTest.java
+++ b/src/test/java/org/folio/rest/camunda/utility/MappingParametersTypeTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Objects;
 import java.util.stream.Stream;
-
 import org.folio.AlternativeTitleType;
 import org.folio.Alternativetitletypes;
 import org.folio.CallNumberType;
@@ -56,10 +55,6 @@ import org.folio.StatisticalCode;
 import org.folio.StatisticalCodeType;
 import org.folio.Statisticalcodes;
 import org.folio.Statisticalcodetypes;
-import org.folio.SubjectSource;
-import org.folio.SubjectSources;
-import org.folio.SubjectType;
-import org.folio.SubjectTypes;
 import org.folio.rest.camunda.utility.MappingParametersType.ParametersTypeLookupException;
 import org.folio.rest.jaxrs.model.MarcFieldProtectionSetting;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,9 +98,7 @@ class MappingParametersTypeTest {
       Arguments.of(MappingParametersType.MATERIAL_TYPES, Mtype.class),
       Arguments.of(MappingParametersType.NATURE_OF_CONTENT_TERMS, NatureOfContentTerm.class),
       Arguments.of(MappingParametersType.STATISTICAL_CODE_TYPES, StatisticalCodeType.class),
-      Arguments.of(MappingParametersType.STATISTICAL_CODES, StatisticalCode.class),
-      Arguments.of(MappingParametersType.SUBJECT_SOURCES, SubjectSource.class),
-      Arguments.of(MappingParametersType.SUBJECT_TYPES, SubjectType.class));
+      Arguments.of(MappingParametersType.STATISTICAL_CODES, StatisticalCode.class));
   }
 
   @ParameterizedTest
@@ -140,9 +133,7 @@ class MappingParametersTypeTest {
       Arguments.of(MappingParametersType.MATERIAL_TYPES, Materialtypes.class),
       Arguments.of(MappingParametersType.NATURE_OF_CONTENT_TERMS, Natureofcontentterms.class),
       Arguments.of(MappingParametersType.STATISTICAL_CODE_TYPES, Statisticalcodetypes.class),
-      Arguments.of(MappingParametersType.STATISTICAL_CODES, Statisticalcodes.class),
-      Arguments.of(MappingParametersType.SUBJECT_SOURCES, SubjectSources.class),
-      Arguments.of(MappingParametersType.SUBJECT_TYPES, SubjectTypes.class));
+      Arguments.of(MappingParametersType.STATISTICAL_CODES, Statisticalcodes.class));
   }
 
   @ParameterizedTest
@@ -177,9 +168,7 @@ class MappingParametersTypeTest {
       Arguments.of(MappingParametersType.MATERIAL_TYPES, "/material-types"),
       Arguments.of(MappingParametersType.NATURE_OF_CONTENT_TERMS, "/nature-of-content-terms"),
       Arguments.of(MappingParametersType.STATISTICAL_CODE_TYPES, "/statistical-code-types"),
-      Arguments.of(MappingParametersType.STATISTICAL_CODES, "/statistical-codes"),
-      Arguments.of(MappingParametersType.SUBJECT_SOURCES, "/subject-sources"),
-      Arguments.of(MappingParametersType.SUBJECT_TYPES, "/subject-types"));
+      Arguments.of(MappingParametersType.STATISTICAL_CODES, "/statistical-codes"));
   }
 
   @ParameterizedTest
@@ -214,9 +203,7 @@ class MappingParametersTypeTest {
       Arguments.of(MappingParametersType.MATERIAL_TYPES, "/material-types?limit=" + LIMIT),
       Arguments.of(MappingParametersType.NATURE_OF_CONTENT_TERMS, "/nature-of-content-terms?limit=" + LIMIT),
       Arguments.of(MappingParametersType.STATISTICAL_CODE_TYPES, "/statistical-code-types?limit=" + LIMIT),
-      Arguments.of(MappingParametersType.STATISTICAL_CODES, "/statistical-codes?limit=" + LIMIT),
-      Arguments.of(MappingParametersType.SUBJECT_SOURCES, "/subject-sources?limit=" + LIMIT),
-      Arguments.of(MappingParametersType.SUBJECT_TYPES, "/subject-types?limit=" + LIMIT));
+      Arguments.of(MappingParametersType.STATISTICAL_CODES, "/statistical-codes?limit=" + LIMIT));
   }
 
   @ParameterizedTest
@@ -258,9 +245,7 @@ class MappingParametersTypeTest {
       Arguments.of(MappingParametersType.MATERIAL_TYPES, Mtype.class, null),
       Arguments.of(MappingParametersType.NATURE_OF_CONTENT_TERMS, NatureOfContentTerm.class, null),
       Arguments.of(MappingParametersType.STATISTICAL_CODE_TYPES, StatisticalCodeType.class, null),
-      Arguments.of(MappingParametersType.STATISTICAL_CODES, StatisticalCode.class, null),
-      Arguments.of(MappingParametersType.SUBJECT_SOURCES, SubjectSource.class, null),
-      Arguments.of(MappingParametersType.SUBJECT_TYPES, SubjectType.class, null));
+      Arguments.of(MappingParametersType.STATISTICAL_CODES, StatisticalCode.class, null));
   }
 
 }

--- a/src/test/java/org/folio/rest/camunda/utility/MappingUtilityTest.java
+++ b/src/test/java/org/folio/rest/camunda/utility/MappingUtilityTest.java
@@ -25,8 +25,6 @@ import static org.folio.rest.camunda.utility.MappingParametersType.MATERIAL_TYPE
 import static org.folio.rest.camunda.utility.MappingParametersType.NATURE_OF_CONTENT_TERMS;
 import static org.folio.rest.camunda.utility.MappingParametersType.STATISTICAL_CODES;
 import static org.folio.rest.camunda.utility.MappingParametersType.STATISTICAL_CODE_TYPES;
-import static org.folio.rest.camunda.utility.MappingParametersType.SUBJECT_SOURCES;
-import static org.folio.rest.camunda.utility.MappingParametersType.SUBJECT_TYPES;
 import static org.folio.rest.camunda.utility.MappingParametersUtility.LIMIT;
 import static org.folio.rest.camunda.utility.MappingParametersUtility.MAPPING_RULES_PATH;
 import static org.folio.rest.camunda.utility.TestUtility.i;
@@ -35,13 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.folio.Alternativetitletypes;
 import org.folio.Callnumbertypes;
 import org.folio.Classificationtypes;
@@ -67,8 +64,6 @@ import org.folio.Materialtypes;
 import org.folio.Natureofcontentterms;
 import org.folio.Statisticalcodes;
 import org.folio.Statisticalcodetypes;
-import org.folio.SubjectSources;
-import org.folio.SubjectTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -114,8 +109,6 @@ class MappingUtilityTest {
     mockJsonResponse("Natureofcontentterms.json", NATURE_OF_CONTENT_TERMS.getPath(LIMIT), Natureofcontentterms.class);
     mockJsonResponse("Statisticalcodes.json", STATISTICAL_CODES.getPath(LIMIT), Statisticalcodes.class);
     mockJsonResponse("Statisticalcodetypes.json", STATISTICAL_CODE_TYPES.getPath(LIMIT), Statisticalcodetypes.class);
-    mockJsonResponse("Subjectsources.json", SUBJECT_SOURCES.getPath(LIMIT), SubjectSources.class);
-    mockJsonResponse("Subjecttypes.json", SUBJECT_TYPES.getPath(LIMIT), SubjectTypes.class);
 
     MappingUtility.restTemplate = mockRestTemplate;
   }


### PR DESCRIPTION
Revert the current changes regarding these two end points.

There will be tickets created on the back log to allow for better planning and updating of all of these end points for the latest flower release.