### PR TITLE
Add Spring Context Accessor for Static Access to Tenant Properties

### DIFF
--- a/src/main/java/org/folio/rest/camunda/SpringContextAccessor.java
+++ b/src/main/java/org/folio/rest/camunda/SpringContextAccessor.java
@@ -26,6 +26,7 @@ public class SpringContextAccessor implements ApplicationContextAware {
    *                        context
    */
   @Override
+  @SuppressWarnings("java:S2696") // SonarQube static assignment from non-static method.
   public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
     context = applicationContext;
   }

--- a/src/main/java/org/folio/rest/camunda/SpringContextAccessor.java
+++ b/src/main/java/org/folio/rest/camunda/SpringContextAccessor.java
@@ -1,0 +1,44 @@
+package org.folio.rest.camunda;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * SpringContextAccessor is a utility class that provides access to the Spring
+ * application context.
+ *
+ * It implements ApplicationContextAware to automatically set the application
+ * context when the Spring container starts.
+ */
+@Component
+public class SpringContextAccessor implements ApplicationContextAware {
+
+  private static ApplicationContext context;
+
+  /**
+   * Sets the application context. This method is called by the Spring framework
+   * when the application context is initialized.
+   *
+   * @param applicationContext the application context to set
+   * @throws BeansException if an error occurs while setting the application
+   *                        context
+   */
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    context = applicationContext;
+  }
+
+  /**
+   * Retrieves a bean from the application context by its class type.
+   *
+   * @param <T>       the type of the bean to retrieve
+   * @param beanClass the class of the bean to retrieve
+   * @return the bean instance
+   */
+  public static <T> T getBean(Class<T> beanClass) {
+    return context.getBean(beanClass);
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/config/CamundaTenantInit.java
+++ b/src/main/java/org/folio/rest/camunda/config/CamundaTenantInit.java
@@ -1,12 +1,11 @@
 package org.folio.rest.camunda.config;
 
-import jakarta.annotation.PostConstruct;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
+
 import org.folio.spring.tenant.hibernate.HibernateTenantInit;
-import org.folio.spring.tenant.properties.TenantProperties;
 import org.folio.spring.tenant.service.SqlTemplateService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -14,30 +13,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class CamundaTenantInit implements HibernateTenantInit {
 
-  /**
-   * HTTP header name for providing the authentication token.
-   */
-  public static final String OKAPI_TOKEN_HEADER = "X-Okapi-Token";
-
   private static final String SCHEMA_IMPORT_TENANT = "import/tenant";
 
   private static final String TENANT_TEMPLATE_KEY = "tenant";
 
-  private static String TENANT_HEADER_NAME;
-
   private SqlTemplateService sqlTemplateService;
 
-  private TenantProperties tenantProperties;
-
   @Autowired
-  public CamundaTenantInit(SqlTemplateService sqlTemplateService, TenantProperties tenantProperties) {
+  public CamundaTenantInit(SqlTemplateService sqlTemplateService) {
     this.sqlTemplateService = sqlTemplateService;
-    this.tenantProperties = tenantProperties;
-  }
-
-  @PostConstruct
-  public void initializeStaticTenantHeader() {
-    TENANT_HEADER_NAME = tenantProperties.getHeaderName();
   }
 
   @Override
@@ -49,23 +33,6 @@ public class CamundaTenantInit implements HibernateTenantInit {
     try (Statement statement = connection.createStatement()) {
       statement.execute(sqlTemplateService.templateInitSql(SCHEMA_IMPORT_TENANT, TENANT_TEMPLATE_KEY, camundaTenant));
     }
-  }
-
-  /**
-   * Provide a static way get the tenant header name value.
-   *
-   * The yaml file names this `tenant.header-name`.
-   * The environment variable for this is `TENANT_HEADERNAME`.
-   *
-   * The OkapiRestTemplate design prevents auto-injection because non-Java code will run the static methods via the MappingUtility.
-   * Load the settings in such a way that a static method may access settings injected by Spring.
-   *
-   * These settings are normally defined in the Spring-Module-Core Spring-Tenant `TenantProperties` class
-   *
-   * @return the tenant header.
-   */
-  public static String getHeaderName() {
-    return TENANT_HEADER_NAME;
   }
 
   public class CamundaTenant {

--- a/src/main/java/org/folio/rest/camunda/utility/MappingParametersUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/MappingParametersUtility.java
@@ -103,6 +103,7 @@ public class MappingParametersUtility {
    * Used as a constant endpoint for retrieving mapping configuration specific to
    * MARC bibliographic records.
    */
+  @SuppressWarnings("java:S1075")
   static final String MAPPING_RULES_PATH = "/mapping-rules/marc-bib";
 
   private MappingParametersUtility() {

--- a/src/main/java/org/folio/rest/camunda/utility/MappingUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/MappingUtility.java
@@ -46,7 +46,7 @@ public class MappingUtility {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   /** Rest template for making Okapi-based REST calls. */
-  static OkapiRestTemplate restTemplate = new OkapiRestTemplate();
+  static OkapiRestTemplate restTemplate = OkapiRestTemplate.build();
 
   /**
    * Private constructor to prevent instantiation of utility class.

--- a/src/main/java/org/folio/rest/camunda/utility/OkapiRestTemplate.java
+++ b/src/main/java/org/folio/rest/camunda/utility/OkapiRestTemplate.java
@@ -1,12 +1,14 @@
 package org.folio.rest.camunda.utility;
 
+import static org.folio.rest.camunda.SpringContextAccessor.getBean;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import org.folio.rest.camunda.config.CamundaTenantInit;
+
+import org.folio.spring.tenant.properties.TenantProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -19,22 +21,27 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 /**
- * A specialized extension of Spring's {@link RestTemplate} designed specifically
- * for interacting with Okapi-based microservice platforms.
+ * A specialized extension of Spring's {@link RestTemplate} designed
+ * specifically for interacting with Okapi-based microservice platforms.
  *
- * <p>This custom REST template provides a fluent interface for configuring
+ * <p>
+ * This custom REST template provides a fluent interface for configuring
  * Okapi-specific request parameters such as tenant identification,
- * authentication tokens, and base URL handling.</p>
+ * authentication tokens, and base URL handling.
+ * </p>
  *
- * <p>The class follows the builder pattern, allowing for easy and flexible
- * configuration of REST template instances with Okapi-specific requirements.</p>
+ * <p>
+ * The class follows the builder pattern, allowing for easy and flexible
+ * configuration of REST template instances with Okapi-specific requirements.
+ * </p>
  *
- * <p>Key features include:
- * <ul>
- *   <li>Automatic addition of Okapi-specific headers</li>
- *   <li>Fluent configuration methods</li>
- *   <li>Simplified REST template creation</li>
- * </ul>
+ * <p>
+ * Key features include:
+ *   <ul>
+ *     <li>Automatic addition of Okapi-specific headers</li>
+ *     <li>Fluent configuration methods</li>
+ *     <li>Simplified REST template creation</li>
+ *   </ul>
  * </p>
  *
  * @see RestTemplate
@@ -45,39 +52,52 @@ public class OkapiRestTemplate extends RestTemplate {
   private static final Logger LOG = LoggerFactory.getLogger(OkapiRestTemplate.class);
 
   /**
-   * Constructor.
+   * HTTP header name for providing the authentication token.
    */
-  public OkapiRestTemplate() {
+  static final String OKAPI_TOKEN_HEADER = "X-Okapi-Token";
+
+  /**
+   * Private constructor to enforce the use of the {@link #build()} method for
+   * creating instances.
+   *
+   * <p>
+   * This ensures that instances are created through a controlled, configurable
+   * process.
+   * </p>
+   */
+  private OkapiRestTemplate() {
 
   }
 
   /**
    * Configures the REST template with tenant and authentication details.
    *
-   * <p>This method sets up an HTTP request interceptor that automatically
-   * adds Okapi-specific headers to each request:
-   * <ul>
-   *   <li>X-Okapi-Tenant header</li>
-   *   <li>X-Okapi-Token header</li>
-   *   <li>Accepted media types (JSON and plain text)</li>
-   *   <li>Content type (JSON)</li>
-   * </ul>
+   * <p>
+   * This method sets up an HTTP request interceptor that automatically adds
+   * Okapi-specific headers to each request:
+   *   <ul>
+   *     <li>X-Okapi-Tenant header</li>
+   *     <li>X-Okapi-Token header</li>
+   *     <li>Accepted media types (JSON and plain text)</li>
+   *     <li>Content type (JSON)</li>
+   *   </ul>
    * </p>
    *
    * @param tenant the Okapi tenant identifier (must not be null)
-   * @param token the authentication token (must not be null)
+   * @param token  the authentication token (must not be null)
    * @return the configured {@code OkapiRestTemplate} instance
    * @throws IllegalArgumentException if tenant or token is null or empty
    */
   public OkapiRestTemplate with(@NonNull String tenant, @NonNull String token) {
+    final TenantProperties tenantProperties = getBean(TenantProperties.class);
     this.setInterceptors(Collections.singletonList(new ClientHttpRequestInterceptor() {
       @Override
       public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
           throws IOException {
         HttpHeaders headers = request.getHeaders();
 
-        headers.set(CamundaTenantInit.getHeaderName(), tenant);
-        headers.set(CamundaTenantInit.OKAPI_TOKEN_HEADER, token);
+        headers.set(tenantProperties.getHeaderName(), tenant);
+        headers.set(OKAPI_TOKEN_HEADER, token);
 
         headers.setAccept(Arrays.asList(APPLICATION_JSON, TEXT_PLAIN));
         headers.setContentType(APPLICATION_JSON);
@@ -94,8 +114,10 @@ public class OkapiRestTemplate extends RestTemplate {
   /**
    * Configures the base URL for all requests made through this REST template.
    *
-   * <p>This method sets up a {@link DefaultUriBuilderFactory} with the provided
-   * Okapi URL, which will be used as the base for all subsequent REST requests.</p>
+   * <p>
+   * This method sets up a {@link DefaultUriBuilderFactory} with the provided
+   * Okapi URL, which will be used as the base for all subsequent REST requests.
+   * </p>
    *
    * @param okapiUrl the base URL for the Okapi service (must not be null)
    * @return the configured {@code OkapiRestTemplate} instance
@@ -106,6 +128,32 @@ public class OkapiRestTemplate extends RestTemplate {
     this.setUriTemplateHandler(factory);
 
     return this;
+  }
+
+  /**
+   * Creates a new instance of {@code OkapiRestTemplate}.
+   *
+   * <p>
+   * This static factory method provides a fluent way to create and configure an
+   * Okapi-specific REST template. It follows the builder pattern, allowing method
+   * chaining for configuration.
+   * </p>
+   *
+   * <p>
+   * Example usage:
+   *
+   * <pre>{@code
+   * OkapiRestTemplate restTemplate = OkapiRestTemplate.build()
+   *     .with("tenant-id", "auth-token")
+   *     .at("https://okapi.example.edu");
+   * }
+   * </pre>
+   * </p>
+   *
+   * @return a new, unconfigured {@code OkapiRestTemplate} instance
+   */
+  public static OkapiRestTemplate build() {
+    return new OkapiRestTemplate();
   }
 
 }

--- a/src/test/java/org/folio/rest/camunda/SpringContextAccessorTest.java
+++ b/src/test/java/org/folio/rest/camunda/SpringContextAccessorTest.java
@@ -1,0 +1,28 @@
+package org.folio.rest.camunda;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.folio.spring.tenant.properties.TenantProperties;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(
+  classes = {
+    SpringContextAccessor.class,
+    TenantProperties.class
+  },
+  webEnvironment = WebEnvironment.MOCK
+)
+class SpringContextAccessorTest {
+
+  @ParameterizedTest
+  @ValueSource(classes = {
+      TenantProperties.class
+  })
+  void testGetTenantPropertiesBean(Class<?> bean) {
+    assertNotNull(SpringContextAccessor.getBean(bean));
+  }
+
+}


### PR DESCRIPTION
This PR introduces a new utility class, `SpringContextAccessor`, which provides static access to the Spring application context. This allows for the retrieval of beans, such as tenant properties, in a static manner. Additionally, a factory method has been added to `OkapiRestTemplate` to facilitate its creation and configuration using a builder pattern. 

#### Key Changes:
1. **New Utility Class: `SpringContextAccessor`**
   - Implements `ApplicationContextAware` to set the application context automatically when the Spring container starts.
   - Provides a static method `getBean(Class<T> beanClass)` to retrieve beans from the application context.

2. **Factory Method in `OkapiRestTemplate`**
   - Introduces a static factory method `build()` for creating and configuring `OkapiRestTemplate` instances using a fluent API.

3. **Unit Tests**
   - Added `SpringContextAccessorTest` to ensure the correct retrieval of tenant properties bean.
   - Utilizes `SpringBootTest` with mock web environment for testing.

#### Rationale:
- **Static Access to Beans**: The `SpringContextAccessor` allows for easy and static access to Spring-managed beans, which is particularly useful for accessing tenant-specific properties across different parts of the application.
- **Fluent API for `OkapiRestTemplate`**: The factory method enhances the usability of `OkapiRestTemplate` by providing a clear and concise way to instantiate and configure it.
- **Preventing Deserialization**: Making the constructor of `OkapiRestTemplate` private prevents direct instantiation and deserialization, which enhances security by ensuring that instances are only created through the controlled factory method.

- **Improved Test Coverage**: The added tests ensure that the new functionality works as expected and integrates well with the existing application context.

#### Additional Changes:
- Minor test cleanup to improve code readability and maintainability.
