### PR TITLE
RTR Sprint2: Enable ECMA 6 (2024).

### DIFF
--- a/src/main/java/org/folio/rest/camunda/resolver/ScriptEngineResolver.java
+++ b/src/main/java/org/folio/rest/camunda/resolver/ScriptEngineResolver.java
@@ -6,6 +6,7 @@ import javax.script.ScriptEngineManager;
 import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
 
 /**
  * A custom script engine resolver to allow for setting configuration.
@@ -29,8 +30,12 @@ public class ScriptEngineResolver extends DefaultScriptEngineResolver {
       .build();
 
     Context.Builder builder = Context.newBuilder("js")
+      // Enable 2024 version of ECMA as supported by Graaljs in Camunda 7.
+      // see: https://www.graalvm.org/latest/reference-manual/js/ScriptEngine/#manually-creating-context-for-more-flexibility
+      .option("js.ecmascript-version", "2024")
       // Make sure GraalVM JS can provide access to the host and can lookup classes.
-      .allowHostClassLookup(s -> true);
+      .allowHostClassLookup(s -> true)
+      .allowHostAccess(HostAccess.ALL);
 
     return GraalJSScriptEngine.create(engine, builder);
   }


### PR DESCRIPTION
This enables the use of more up to date JavaScripts, namely ECMA 6 as of 2024.
The `2024` is chosen over something newer like `2025` because `2024` is documented to work under Camunda 7.
The `2024` is a huge improvement over ECMA 5.

This allows for much better written JavaScript.
- This includes using `console.log()`, `console.debug()`, etc... instead of `print()`.
- This includes using `const` and `let` instead of `var`.