### PR TITLE
RTR: Replace mailinator e-mails with localhost.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,7 +122,7 @@ camunda:
       password: admin
       first-name: Camunda
       last-name: Admin
-      email: cadmin@mailinator.com
+      email: admin@localhost
     # authorization.enabled: true
     default-number-of-retries: 1
     job-execution:
@@ -231,9 +231,9 @@ management:
 error:
   handling:
     environment: DEV
-    emailFrom: noReply@mailinator.com
+    emailFrom: admin@localhost
     # comma seperated email addresses
-    emailTo: support@mailinator.com
+    emailTo: admin@localhost
 
 info:
   build:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -109,7 +109,7 @@ camunda:
       password: admin
       first-name: Camunda
       last-name: Admin
-      email: cadmin@mailinator.com
+      email: test@localhost
     # authorization.enabled: true
     default-number-of-retries: 1
     job-execution:
@@ -174,9 +174,9 @@ okapi.url: http://localhost:9130
 error:
   handling:
     environment: DEV
-    emailFrom: noReply@mailinator.com
+    emailFrom: test@localhost
     # comma seperated email addresses
-    emailTo: support@mailinator.com
+    emailTo: test@localhost
 
 # https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html
 management:


### PR DESCRIPTION
The default e-mails should never be set to some 3rd-party.

Avoid potentially spamming 3rd-parties by setting the default e-mails to localhost.

Using 3rd-party e-mails by default is also a security concern because this results in stack traces being sent to a 3rd-party (mailinator in this case).