### PR TITLE
Fix object mapping problems regarding dates and times.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,12 @@
       <artifactId>bcprov-jdk18on</artifactId>
       <version>1.83</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.22.1</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
+++ b/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
@@ -1,14 +1,15 @@
 package org.folio.rest.camunda.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.TimeZone;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.model.bpmn.Bpmn;
@@ -55,7 +56,6 @@ import org.folio.rest.workflow.model.components.Task;
 import org.folio.rest.workflow.model.components.Wait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -74,11 +74,24 @@ public class BpmnModelFactory {
   };
   // @formatter:on
 
-  @Autowired
   private ObjectMapper objectMapper;
 
-  @Autowired
   private List<AbstractWorkflowDelegate> workflowDelegates;
+
+  /**
+   * Constructor.
+   *
+   * @param objectMapper The object mapper.
+   * @param workflowDelegates The workflow delegate.
+   */
+  BpmnModelFactory(ObjectMapper objectMapper, List<AbstractWorkflowDelegate> workflowDelegates) {
+    this.objectMapper = objectMapper;
+    this.workflowDelegates = workflowDelegates;
+
+    objectMapper.findAndRegisterModules();
+    objectMapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+    objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
 
   public BpmnModelInstance fromWorkflow(Workflow workflow) throws ScriptTaskDeserializeCodeFailure {
 

--- a/src/test/java/org/folio/rest/camunda/controller/WorkflowControllerTest.java
+++ b/src/test/java/org/folio/rest/camunda/controller/WorkflowControllerTest.java
@@ -35,10 +35,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.lang.reflect.Method;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 import org.folio.rest.camunda.service.CamundaApiService;
 import org.folio.rest.workflow.model.Setup;
@@ -52,8 +53,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -88,8 +87,12 @@ class WorkflowControllerTest {
   private TenantProperties tenantProperties;
 
   @BeforeEach
-  void beforeEach() throws JsonProcessingException {
+  void beforeEach() {
     mvc = MockMvcBuilders.standaloneSetup(workflowController).build();
+
+    // Prevent problems where the object mapper randomly switches time zone thereby causing string comparisons to fail.
+    mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+    mapper.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   @ParameterizedTest
@@ -117,9 +120,13 @@ class WorkflowControllerTest {
 
     if (status == 200) {
       MediaType responseType = MediaType.parseMediaType(result.getResponse().getContentType());
+      String workflowJson = mapper.writeValueAsString(workflow);
 
       assertTrue(mediaType.isCompatibleWith(responseType));
-      assertEquals(mapper.writeValueAsString(workflow), result.getResponse().getContentAsString());
+
+      Workflow responseWorkflow = mapper.readValue(result.getResponse().getContentAsString(), Workflow.class);
+
+      assertEquals(workflowJson, mapper.writeValueAsString(responseWorkflow));
     }
   }
 
@@ -148,9 +155,13 @@ class WorkflowControllerTest {
 
     if (status == 200) {
       MediaType responseType = MediaType.parseMediaType(result.getResponse().getContentType());
+      String workflowJson = mapper.writeValueAsString(workflow);
 
       assertTrue(mediaType.isCompatibleWith(responseType));
-      assertEquals(mapper.writeValueAsString(workflow), result.getResponse().getContentAsString());
+
+      Workflow responseWorkflow = mapper.readValue(result.getResponse().getContentAsString(), Workflow.class);
+
+      assertEquals(workflowJson, mapper.writeValueAsString(responseWorkflow));
     }
   }
 


### PR DESCRIPTION
Switch to `Instant`, which is what is used in later versions of this module.

Set up the WorkflowEngineService to use the construction behavior instead of autowired. Then explicitly configure mapper settings.

This, when paired with similar changes in Workflow for MODWRKFLOW-69, solves this problem on workflow activate attempts:
```
{"errors":[{"message":"Java 8 date/time type `java.time.ZonedDateTime` not supported by default: add Module \\"com.fasterxml.jackson.datatype:jackson-datatype-jsr310\\" to enable handling\\n at [Source: (org.springframework.util.StreamUtils$NonClosingInputStream); line: 1, column: 1531] (through reference chain: org.folio.rest.workflow.model.Workflow[\\"createdOn\\"])"
```

Note: Investigation has shown that these problems were fixed as part of the **Spring Boot 4** upgrades and therefore do not need to be applied upstream.