### PR TITLE
Issue 302: Ensure Java time stamps work.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>spring-module-core</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>mod-camunda</artifactId>
@@ -380,6 +380,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>2.22.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/folio/rest/camunda/utility/MappingUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/MappingUtility.java
@@ -1,10 +1,16 @@
 package org.folio.rest.camunda.utility;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.util.Map;
@@ -43,7 +49,14 @@ public class MappingUtility {
   private static final MarcToInstanceMapper marcToInstanceMapper = new MarcToInstanceMapper();
 
   /** Jackson ObjectMapper for JSON serialization and deserialization. */
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = JsonMapper.builder()
+    .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+    .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+    .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .addModule(new JavaTimeModule())
+    .build();
 
   /** Rest template for making Okapi-based REST calls. */
   static OkapiRestTemplate restTemplate = new OkapiRestTemplate();


### PR DESCRIPTION
Resolves #302

Explicitly bring in `jackson-datatype-jsr310`.

Add `JavaTimeModule`.

Explicitly ensure `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` is enabled.

Switch to `2.1.1-SNAPSHOT` branch that contains the relating changes from that repository.workflowRepo

Utilize the same mapping configuration that the scripts are to be executed with.