### PR TITLE
Issue 305: Back Port MODCAMUNDA-66: Implement sendEmptyBody support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,12 +379,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.22.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -1,6 +1,10 @@
 package org.folio.rest.camunda.delegate;
 
 import static org.camunda.spin.Spin.JSON;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.TRACE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -9,7 +13,6 @@ import freemarker.template.Configuration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
@@ -49,91 +52,64 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   public void execute(DelegateExecution execution) throws Exception {
     final long startTime = determineStartTime(execution);
 
-    Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
+    final Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
 
-    Map<String, Object> inputs = getInputs(execution);
+    final Map<String, Object> inputs = getInputs(execution);
+    final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
 
-    Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+    final String bodyTemplate = requestValue.getBodyTemplate();
+    final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
 
-    StringTemplateLoader stringLoader = new StringTemplateLoader();
+    final StringTemplateLoader stringLoader = new StringTemplateLoader();
     stringLoader.putTemplate("url", requestValue.getUrl());
-    stringLoader.putTemplate("body", requestValue.getBodyTemplate());
+
     cfg.setTemplateLoader(stringLoader);
 
-    String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
-    String body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+    String body = null;
 
-    HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
-    String accept = requestValue.getAccept();
-    String contentType = requestValue.getContentType();
+    if (bodyTemplate != null) {
+      stringLoader.putTemplate("body", requestValue.getBodyTemplate());
 
-    String tenant = execution.getTenantId();
+      body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+    }
 
-    Optional<Object> token = Optional.ofNullable(execution.getVariable("X-Okapi-Token"));
+    final String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+
+    final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
+    final String accept = requestValue.getAccept();
+    final String contentType = requestValue.getContentType();
+
+    final String tenant = execution.getTenantId();
+    final Object token = execution.getVariable("X-Okapi-Token");
 
     getLogger().info("url: {}", url);
     getLogger().debug("method: {}", method);
+    getLogger().debug("sendEmptyBody: {}", sendEmptyBody);
 
     getLogger().debug("accept: {}", accept);
     getLogger().debug("content-type: {}", contentType);
     getLogger().debug("tenant: {}", tenant);
 
-    HttpHeaders headers = new HttpHeaders();
+    final HttpHeaders headers = new HttpHeaders();
     headers.add("Accept", accept);
     headers.add("Content-Type", contentType);
     headers.add("X-Okapi-Tenant", tenant);
     headers.add("X-Okapi-Url", okapiUrl);
 
-    if (token.isPresent()) {
-      headers.add("X-Okapi-Token", token.get().toString());
+    if (token != null) {
+      headers.add("X-Okapi-Token", token.toString());
     }
 
-    HttpEntity<Object> entity = new HttpEntity<>(body, headers);
-    ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
+    final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
+      ? new HttpEntity<>(body, headers)
+      : new HttpEntity<>(headers);
+
+    final ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
 
     setOutput(execution, response.getBody());
 
-    getHeaderOutputVariables(execution).forEach(headerOutputVariable -> {
-      if (headerOutputVariable.getKey() != null) {
-        VariableType type = headerOutputVariable.getType();
-        String key = headerOutputVariable.getKey();
-
-        if (response.getHeaders().containsKey(key)) {
-          if (type != null) {
-            Object value = null;
-
-            if (headerOutputVariable.getAsArray()) {
-              List<String> valueList = new ArrayList<>();
-
-              if (response.getHeaders().containsKey(key)) {
-                valueList.addAll(response.getHeaders().get(key));
-              }
-
-              value = spinValue(headerOutputVariable, valueList);
-            } else {
-              value = spinValue(headerOutputVariable, response.getHeaders().getFirst(key));
-            }
-
-            switch (type) {
-              case LOCAL:
-                execution.setVariableLocal(key, value);
-                break;
-              case PROCESS:
-                execution.setVariable(key, value);
-                break;
-              default:
-                break;
-            }
-          } else {
-            getLogger().warn("Variable type not present for {}.", key);
-          }
-        } else {
-          getLogger().warn("Header output not present for {}.", key);
-        }
-      } else {
-        getLogger().warn("Header output key is not found in the response.");
-      }
-    });
+    getHeaderOutputVariables(execution)
+      .forEach(headerOutputVariable -> performExecuteHeaderOutputVariables(execution, headerOutputVariable, response));
 
     determineEndTime(execution, startTime);
   }
@@ -157,6 +133,95 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
         new TypeReference<Set<EmbeddedVariable>>() {});
     // @formatter:on
   }
+
+  /**
+   * Perform the delegate execution relating to header output variables.
+   *
+   * @param execution            The delegate execution data.
+   * @param headerOutputVariable The embedded variable.
+   */
+  private void performExecuteHeaderOutputVariables(
+    final DelegateExecution execution, final EmbeddedVariable headerOutputVariable, final ResponseEntity<Object> response
+  ) {
+
+    if (headerOutputVariable.getKey() != null) {
+      VariableType type = headerOutputVariable.getType();
+      String key = headerOutputVariable.getKey();
+
+      if (response.getHeaders().containsKey(key)) {
+        if (type != null) {
+          final Object value = performExecuteHeaderOutputVariablesSpin(headerOutputVariable, response.getHeaders(), key);
+
+          switch (type) {
+            case LOCAL:
+              execution.setVariableLocal(key, value);
+              break;
+            case PROCESS:
+              execution.setVariable(key, value);
+              break;
+            default:
+              break;
+          }
+        } else {
+          getLogger().warn("Variable type not present for {}.", key);
+        }
+      } else {
+        getLogger().warn("Header output not present for {}.", key);
+      }
+    } else {
+      getLogger().warn("Header output key is not found in the response.");
+    }
+  }
+
+  /**
+   * Perform the delegate execution relating to header output variables for spin.
+   *
+   * @param headerOutputVariable The embedded variable.
+   * @param headers              The HTTP headers.
+   * @param key                  The key representing the array index.
+   *
+   * @return The value, after "spinning".
+   */
+  private Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
+
+    if (Boolean.TRUE.equals(headerOutputVariable.getAsArray())) {
+      final List<String> valueList = new ArrayList<>();
+
+      if (headers.containsKey(key)) {
+        valueList.addAll(headers.get(key));
+      }
+
+      return spinValue(headerOutputVariable, valueList);
+    }
+
+    return spinValue(headerOutputVariable, headers.getFirst(key));
+  }
+
+  /**
+   * Determine if HTML body section should be sent or not.
+   *
+   * The body string, the HTTP method, and the sendEmptyBody are all used to determine whether or not the body should be sent.
+   * If this returns true, then the body should be sent regardless of whether or not it is NULL or some string.
+   *
+   * The HTTP TRACE must never send an HTTP body section.
+   *
+   * @param body          The body string.
+   * @param sendEmptyBody Whether or not to send an empty body.
+   * @param method        The HTTP Method.
+   *
+   * @return TRUE on send body and FALSE otherwise.
+   */
+  private boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
+
+    if (TRACE.equals(method)) return false;
+
+    if ((body == null || body.isEmpty()) && (DELETE.equals(method) || GET.equals(method) || HEAD.equals(method))) {
+      return Boolean.TRUE.equals(sendEmptyBody);
+    }
+
+    return true;
+  }
+
 
   /**
    * Conditional spin the value if spin is enabled.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ logging:
         hikari: INFO
     org:
       camunda: INFO
+      camunda.bpm.engine.jobexecutor: ERROR
       folio: INFO
       hibernate: INFO
       springframework: INFO


### PR DESCRIPTION
Resolves #305 .

Utilize the `sendEmptyBody` property.
Ensure that the `body` is properly sent.
When the `sendEmptyBody` is FALSE and the body is NULL or an empty string, then do not send the body variable to the request function. Make this logic aware of the **HTTP** methods.

Do not attempt to use freemarker on the `bodyTemplate` when it is NULL. Add logging for the `sendEmptyBody` property.
Conditionally send body based on the various conditions.

Note: The issue was retroactively created so the branch name is inconsistent.