### PR TITLE
Issue 307: Back Port MODCAMUNDA-68: Implement FolioRequestDelagate based off of RequestDelegate.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/delegate/FolioRequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FolioRequestDelegate.java
@@ -1,0 +1,98 @@
+package org.folio.rest.camunda.delegate;
+
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
+import java.util.Map;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.folio.rest.workflow.dto.Request;
+import org.folio.rest.workflow.model.FolioRequestTask;
+import org.folio.spring.web.service.HttpService;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+/**
+ * A delegate for performing already logged in FOLIO HTTP requests.
+ *
+ * For logging into FOLIO, use the RequestDelegate instead.
+ */
+@Service
+@Scope("prototype")
+public class FolioRequestDelegate extends RequestDelegate {
+
+  public FolioRequestDelegate(HttpService httpService) {
+    super(httpService);
+  }
+
+  @Override
+  public Class<?> fromTask() {
+    return FolioRequestTask.class;
+  }
+
+  /**
+   * Perform the execution.
+   *
+   * @param execution The execution data.
+   * @param name      The delegate name.
+   * @param id        The delegate ID.
+   */
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+
+    final long startTime = determineStartTime(execution);
+
+    final Map<String, Object> inputs = getInputs(execution);
+    final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+
+    final Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
+    final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
+
+    final StringTemplateLoader loader = new StringTemplateLoader();
+    cfg.setTemplateLoader(loader);
+
+    final String body = performExecuteBuildBody(requestValue.getBodyTemplate(), loader, cfg, inputs);
+    final String url = performExecuteBuildUrl(requestValue.getUrl(), loader, cfg, inputs);
+
+    final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
+    final String accept = requestValue.getAccept();
+    final String contentType = requestValue.getContentType();
+
+    final String tenant = execution.getTenantId();
+    final Object token = execution.getVariable("X-Okapi-Token");
+
+    getLogger().info("url: {}", url);
+    getLogger().debug("method: {}", method);
+    getLogger().debug("sendEmptyBody: {}", sendEmptyBody);
+
+    getLogger().debug("accept: {}", accept);
+    getLogger().debug("content-type: {}", contentType);
+    getLogger().debug("tenant: {}", tenant);
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add("Accept", accept);
+    headers.add("Content-Type", contentType);
+    headers.add("X-Okapi-Tenant", tenant);
+    headers.add("X-Okapi-Url", okapiUrl);
+
+    if (token != null) {
+      headers.add("X-Okapi-Token", token.toString());
+    }
+
+    final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
+      ? new HttpEntity<>(body, headers)
+      : new HttpEntity<>(headers);
+
+    final ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
+
+    setOutput(execution, response.getBody());
+
+    getHeaderOutputVariables(execution)
+      .forEach(headerOutputVariable -> performExecuteHeaderOutputVariables(execution, headerOutputVariable, response));
+
+    determineEndTime(execution, startTime);
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,18 +33,23 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 
+/**
+ * A delegate for performing already logged in FOLIO HTTP requests.
+ *
+ * For FOLIO related requests other than logging, use the FolioRequestDelegate instead.
+ */
 @Service
 @Scope("prototype")
 public class RequestDelegate extends AbstractWorkflowIODelegate {
 
   @Value("${okapi.url}")
-  private String okapiUrl;
+  protected String okapiUrl;
 
-  private HttpService httpService;
+  protected HttpService httpService;
 
-  private Expression request;
+  protected Expression request;
 
-  private Expression headerOutputVariables;
+  protected Expression headerOutputVariables;
 
   public RequestDelegate(HttpService httpService) {
     this.httpService = httpService;
@@ -50,37 +57,24 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
 
-    final Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
+    final long startTime = determineStartTime(execution);
 
     final Map<String, Object> inputs = getInputs(execution);
     final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
 
-    final String bodyTemplate = requestValue.getBodyTemplate();
+    final Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
     final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
 
-    final StringTemplateLoader stringLoader = new StringTemplateLoader();
-    stringLoader.putTemplate("url", requestValue.getUrl());
+    final StringTemplateLoader loader = new StringTemplateLoader();
+    cfg.setTemplateLoader(loader);
 
-    cfg.setTemplateLoader(stringLoader);
-
-    String body = null;
-
-    if (bodyTemplate != null) {
-      stringLoader.putTemplate("body", requestValue.getBodyTemplate());
-
-      body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
-    }
-
-    final String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+    final String body = performExecuteBuildBody(requestValue.getBodyTemplate(), loader, cfg, inputs);
+    final String url = performExecuteBuildUrl(requestValue.getUrl(), loader, cfg, inputs);
 
     final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
     final String accept = requestValue.getAccept();
     final String contentType = requestValue.getContentType();
-
-    final String tenant = execution.getTenantId();
-    final Object token = execution.getVariable("X-Okapi-Token");
 
     getLogger().info("url: {}", url);
     getLogger().debug("method: {}", method);
@@ -88,17 +82,10 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
 
     getLogger().debug("accept: {}", accept);
     getLogger().debug("content-type: {}", contentType);
-    getLogger().debug("tenant: {}", tenant);
 
     final HttpHeaders headers = new HttpHeaders();
     headers.add("Accept", accept);
     headers.add("Content-Type", contentType);
-    headers.add("X-Okapi-Tenant", tenant);
-    headers.add("X-Okapi-Url", okapiUrl);
-
-    if (token != null) {
-      headers.add("X-Okapi-Token", token.toString());
-    }
 
     final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
       ? new HttpEntity<>(body, headers)
@@ -135,12 +122,62 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   }
 
   /**
+   * Build the body from the body template.
+   *
+   * @param template The body template.
+   * @param loader   The string loader.
+   * @param cfg      The configuration.
+   * @param inputs   The inputs.
+   *
+   * @return The built body or NULL if there is no template.
+   *
+   * @throws IOException       On error.
+   * @throws TemplateException On error.
+   */
+  protected String performExecuteBuildBody(final String template, final StringTemplateLoader loader, final Configuration cfg, final Map<String, Object> inputs)
+      throws IOException, TemplateException {
+
+    if (template == null) {
+      return null;
+    }
+
+    loader.putTemplate("body", template);
+
+    return FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+  }
+
+  /**
+   * Build the body from the URL.
+   *
+   * @param template The URL.
+   * @param loader   The string loader.
+   * @param cfg      The configuration.
+   * @param inputs   The inputs.
+   *
+   * @return The built URL or NULL if there is no URL.
+   *
+   * @throws IOException       On error.
+   * @throws TemplateException On error.
+   */
+  protected String performExecuteBuildUrl(final String url, final StringTemplateLoader loader, final Configuration cfg, final Map<String, Object> inputs)
+      throws IOException, TemplateException {
+
+    if (url == null) {
+      return null;
+    }
+
+    loader.putTemplate("url", url);
+
+    return FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+  }
+
+  /**
    * Perform the delegate execution relating to header output variables.
    *
    * @param execution            The delegate execution data.
    * @param headerOutputVariable The embedded variable.
    */
-  private void performExecuteHeaderOutputVariables(
+  protected void performExecuteHeaderOutputVariables(
     final DelegateExecution execution, final EmbeddedVariable headerOutputVariable, final ResponseEntity<Object> response
   ) {
 
@@ -182,7 +219,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @return The value, after "spinning".
    */
-  private Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
+  protected Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
 
     if (Boolean.TRUE.equals(headerOutputVariable.getAsArray())) {
       final List<String> valueList = new ArrayList<>();
@@ -211,7 +248,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @return TRUE on send body and FALSE otherwise.
    */
-  private boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
+  protected boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
 
     if (TRACE.equals(method)) return false;
 
@@ -233,7 +270,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @throws DelegateSpinFailure On spin error.
    */
-  private Object spinValue(EmbeddedVariable variable, Object value) throws DelegateSpinFailure {
+  protected Object spinValue(EmbeddedVariable variable, Object value) throws DelegateSpinFailure {
     try {
       return variable.getSpin() ? JSON(objectMapper.writeValueAsString(value)) : value;
     } catch (JsonProcessingException e) {

--- a/src/test/java/org/folio/rest/camunda/delegate/FolioRequestDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FolioRequestDelegateTest.java
@@ -7,6 +7,7 @@ import static org.folio.spring.test.mock.MockMvcConstant.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +23,7 @@ import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.dto.Request;
 import org.folio.rest.workflow.enums.VariableType;
 import org.folio.rest.workflow.model.EmbeddedVariable;
-import org.folio.rest.workflow.model.RequestTask;
+import org.folio.rest.workflow.model.FolioRequestTask;
 import org.folio.spring.web.service.HttpService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
-class RequestDelegateTest {
+class FolioRequestDelegateTest {
 
   private static final String TOKEN_HEADER_NAME = "X-Okapi-Token";
 
@@ -57,7 +58,7 @@ class RequestDelegateTest {
   private Expression requestExpression;
 
   @InjectMocks
-  private RequestDelegate requestDelegate;
+  private FolioRequestDelegate delegate;
 
   @Mock
   ResponseEntity<Object> responseEntity;
@@ -75,7 +76,7 @@ class RequestDelegateTest {
   private HttpHeaders httpHeaders;
 
   @BeforeEach
-  void beforeEach() throws JsonProcessingException {
+  void beforeEach() {
     mapper = new ObjectMapper();
 
     request = new Request();
@@ -101,7 +102,7 @@ class RequestDelegateTest {
 
     when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution, never()).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -115,7 +116,7 @@ class RequestDelegateTest {
 
     setupExecuteMocking(true);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -130,7 +131,7 @@ class RequestDelegateTest {
 
     setupExecuteMocking(true);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -143,7 +144,7 @@ class RequestDelegateTest {
 
     setupExecuteMocking(true);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution, never()).setVariable(anyString(), any());
     verify(delegateExecution).setVariableLocal(anyString(), any());
@@ -156,7 +157,7 @@ class RequestDelegateTest {
 
     setupExecuteMocking(true);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -170,7 +171,20 @@ class RequestDelegateTest {
 
     when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
+
+    verify(delegateExecution, never()).setVariable(anyString(), any());
+    verify(delegateExecution, never()).setVariableLocal(anyString(), any());
+  }
+
+  @Test
+  void testExecuteWorksWithToken() throws Exception {
+    setupExecuteMocking(false);
+
+    when(delegateExecution.getVariable(eq(TOKEN_HEADER_NAME))).thenReturn(UUID);
+    when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
+
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution, never()).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -184,7 +198,7 @@ class RequestDelegateTest {
 
     setupExecuteMocking(true);
 
-    requestDelegate.execute(delegateExecution);
+    delegate.execute(delegateExecution);
 
     verify(delegateExecution, never()).setVariable(anyString(), any());
     verify(delegateExecution, never()).setVariableLocal(anyString(), any());
@@ -192,23 +206,23 @@ class RequestDelegateTest {
 
   @Test
   void testSetHeaderOutputVariablesWorks() {
-    setField(requestDelegate, "headerOutputVariables", null);
+    setField(delegate, "headerOutputVariables", null);
 
-    requestDelegate.setHeaderOutputVariables(requestExpression);
-    assertEquals(requestExpression, getField(requestDelegate, "headerOutputVariables"));
+    delegate.setHeaderOutputVariables(requestExpression);
+    assertEquals(requestExpression, getField(delegate, "headerOutputVariables"));
   }
 
   @Test
   void testSetRequestWorks() {
-    setField(requestDelegate, "request", null);
+    setField(delegate, "request", null);
 
-    requestDelegate.setRequest(requestExpression);
-    assertEquals(requestExpression, getField(requestDelegate, "request"));
+    delegate.setRequest(requestExpression);
+    assertEquals(requestExpression, getField(delegate, "request"));
   }
 
   @Test
   void testFromTaskWorks() {
-    assertEquals(RequestTask.class, requestDelegate.fromTask());
+    assertEquals(FolioRequestTask.class, delegate.fromTask());
   }
 
   /**
@@ -219,15 +233,16 @@ class RequestDelegateTest {
    * @throws JsonProcessingException
    */
   private void setupExecuteMocking(boolean hasKey) throws JsonProcessingException {
-    setField(requestDelegate, "headerOutputVariables", headerOutputVariablesExpression);
-    setField(requestDelegate, "httpService", httpService);
-    setField(requestDelegate, "request", requestExpression);
-    setField(requestDelegate, "objectMapper", mapper);
+    setField(delegate, "headerOutputVariables", headerOutputVariablesExpression);
+    setField(delegate, "httpService", httpService);
+    setField(delegate, "request", requestExpression);
+    setField(delegate, "objectMapper", mapper);
 
     if (hasKey) {
       embeddedVariable.setKey(TOKEN_HEADER_NAME);
       setField(responseEntity, "headers", httpHeaders);
 
+      when(delegateExecution.getVariable(eq(TOKEN_HEADER_NAME))).thenReturn(UUID);
       when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
     }
 


### PR DESCRIPTION
Resolves #307 .

Update the `RequestDelegate` to make it easier to extend.

Extend `RequestDelegate` as `FolioRequestDelagate`.

Add execution details to `FolioRequestDelagate` that includes the **FOLIO** headers.

Remove execution defailts that are no longer needed from `RequestDelegate`, such as removing the **FOLIO** headers.


## References

- [MODCAMUNDA-68](https://folio-org.atlassian.net/browse/MODCAMUNDA-68)