### PR TITLE
Issue 309: Back port: MODCAMUNDA-69: Handle NULL values with GuardedString.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/model/FolioEnvDefaultsItem.java
+++ b/src/main/java/org/folio/rest/camunda/model/FolioEnvDefaultsItem.java
@@ -108,6 +108,12 @@ public class FolioEnvDefaultsItem {
       return false;
     }
 
+    if (guard == null) {
+      LOG.warn("Attempted secure fetch of FOLIO env defaults item '{}', but value is NULL.", name);
+
+      return false;
+    }
+
     guard.access(accessor);
 
     return true;
@@ -234,9 +240,9 @@ public class FolioEnvDefaultsItem {
    */
   void prepareByTypeForSecure(String value) {
 
-    if (value == null) return;
-
-    guard = new GuardedString(value.toCharArray());
+    guard = value == null
+      ? new GuardedString()
+      : new GuardedString(value.toCharArray());
   }
 
   /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -194,14 +194,14 @@ folio:
       - name: gatewayUrl
         type: url
       - name: folioAccessToken
-        type: literal
+        type: secure
       - name: folioRefreshToken
-        type: literal
+        type: secure
       - name: folioTenant
         type: literal
         value: diku
       - name: folioToken
-        type: literal
+        type: secure
 
 tenant:
   header-name: X-Okapi-Tenant

--- a/src/test/java/org/folio/rest/camunda/model/FolioEnvDefaultsItemTest.java
+++ b/src/test/java/org/folio/rest/camunda/model/FolioEnvDefaultsItemTest.java
@@ -89,6 +89,18 @@ class FolioEnvDefaultsItemTest {
     verify(guard, never()).access(accessor);
   }
 
+  @Test
+  void getSecureHandlesNullTest() {
+
+    setField(item, TYPE.getName(), SECURE);
+    setField(item, GUARD, null);
+
+    final boolean result = item.getSecure(accessor);
+
+    assertFalse(result);
+    verify(guard, never()).access(accessor);
+  }
+
   @ParameterizedTest
   @MethodSource("provideGettersWorksValues")
   void gettersWorkTest(String field, Object initial, Object expect, String name)


### PR DESCRIPTION
Further resolves #309.

The `GuardedString` must also handle the case where **NULL** is used.

The variables, like `folioToken`, may be initialized to **NULL** initially.

Change the logic to always instantiate the `GuardedString`. Then, handle the **NULL** value.

Do not error on **NULL**.
Instead, print a warning.
If things are **NULL** then it can be treated as nothing. The return status for the `getSecure()` will be `false` without error. Print a warning to the log in this situation.

Ensure variables like `folioAccessToken` are secure as well.